### PR TITLE
[BE] 토론에 대한 좋아요, 좋아요 취소 API 구현

### DIFF
--- a/.idea/dialog.iml
+++ b/.idea/dialog.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/dialog.iml" filepath="$PROJECT_DIR$/.idea/dialog.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="11743a5e-085b-46e9-b8b9-79ad253c817f" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
+  "lastFilter": {
+    "state": "OPEN",
+    "assignee": "abc5259"
+  }
+}]]></component>
+  <component name="GithubPullRequestsUISettings"><![CDATA[{
+  "selectedUrlAndAccountId": {
+    "url": "https://github.com/woowacourse-dialog/dialog.git",
+    "accountId": "97459680-bdaf-4f6f-8283-c2f32488c002"
+  }
+}]]></component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 2
+}]]></component>
+  <component name="ProjectId" id="2wwF4JLEEZzMu7y8whLTBsT4sS1" />
+  <component name="ProjectViewState">
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "git-widget-placeholder": "develop",
+    "kotlin-language-version-configured": "true",
+    "settings.editor.selected.configurable": "preferences.updates"
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="11743a5e-085b-46e9-b8b9-79ad253c817f" name="Changes" comment="" />
+      <created>1746944536534</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1746944536534</updated>
+    </task>
+    <servers />
+  </component>
+</project>

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -30,7 +30,7 @@
 # Gradle
 .idea/**/gradle.xml
 .idea/**/libraries
-
+.idea
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
@@ -176,3 +176,4 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,macos,java,gradle
+application-secret.yml

--- a/server/src/main/java/com/dialog/server/ServerApplication.java
+++ b/server/src/main/java/com/dialog/server/ServerApplication.java
@@ -2,12 +2,14 @@ package com.dialog.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ServerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ServerApplication.class, args);
+    }
 
 }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
@@ -1,0 +1,27 @@
+package com.dialog.server.controller;
+
+import com.dialog.server.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/discussions/{discussionsId}/likes")
+@RequiredArgsConstructor
+public class DiscussionLikeController {
+
+    private static final Long FAKE_USER_ID = 1L;
+
+    private final LikeService likeService;
+
+    @PostMapping
+    public ResponseEntity<Void> likeDiscussion(@PathVariable("discussionsId") Long discussionsId) {
+        likeService.create(FAKE_USER_ID, discussionsId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .build();
+    }
+}

--- a/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
@@ -4,6 +4,7 @@ import com.dialog.server.service.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,13 @@ public class DiscussionLikeController {
     public ResponseEntity<Void> likeDiscussion(@PathVariable("discussionsId") Long discussionsId) {
         likeService.create(FAKE_USER_ID, discussionsId);
         return ResponseEntity.status(HttpStatus.CREATED)
+                .build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteLikeDiscussion(@PathVariable("discussionsId") Long discussionsId) {
+        likeService.delete(FAKE_USER_ID, discussionsId);
+        return ResponseEntity.noContent()
                 .build();
     }
 }

--- a/server/src/main/java/com/dialog/server/domain/Like.java
+++ b/server/src/main/java/com/dialog/server/domain/Like.java
@@ -8,7 +8,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +32,30 @@ public class Like {
     @ManyToOne
     @JoinColumn(name = "discussion_id", nullable = false)
     private Discussion discussion;
+
+    @Builder
+    private Like(Long id, User user, Discussion discussion) {
+        this.id = id;
+        this.user = user;
+        this.discussion = discussion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Like like = (Like) o;
+        return Objects.equals(id, like.id) && Objects.equals(user, like.user)
+                && Objects.equals(discussion, like.discussion);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(id);
+        result = 31 * result + Objects.hashCode(user);
+        result = 31 * result + Objects.hashCode(discussion);
+        return result;
+    }
 }

--- a/server/src/main/java/com/dialog/server/repository/DiscussionRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/DiscussionRepository.java
@@ -1,0 +1,7 @@
+package com.dialog.server.repository;
+
+import com.dialog.server.domain.Discussion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
+}

--- a/server/src/main/java/com/dialog/server/repository/LikeRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/LikeRepository.java
@@ -8,5 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     boolean existsByUserAndDiscussion(User user, Discussion discussion);
+
+    void deleteByUserIdAndDiscussionId(long userId, long discussionId);
 }
 

--- a/server/src/main/java/com/dialog/server/repository/LikeRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/LikeRepository.java
@@ -1,0 +1,12 @@
+package com.dialog.server.repository;
+
+import com.dialog.server.domain.Discussion;
+import com.dialog.server.domain.Like;
+import com.dialog.server.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    boolean existsByUserAndDiscussion(User user, Discussion discussion);
+}
+

--- a/server/src/main/java/com/dialog/server/repository/UserRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.dialog.server.repository;
+
+import com.dialog.server.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/server/src/main/java/com/dialog/server/service/LikeService.java
+++ b/server/src/main/java/com/dialog/server/service/LikeService.java
@@ -33,6 +33,11 @@ public class LikeService {
         likeRepository.save(like);
     }
 
+    @Transactional
+    public void delete(Long userId, Long discussionId) {
+        likeRepository.deleteByUserIdAndDiscussionId(userId, discussionId);
+    }
+
     private User getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException(userId + "에 해당하는 user를 찾을 수 없습니다."));

--- a/server/src/main/java/com/dialog/server/service/LikeService.java
+++ b/server/src/main/java/com/dialog/server/service/LikeService.java
@@ -1,0 +1,45 @@
+package com.dialog.server.service;
+
+import com.dialog.server.domain.Discussion;
+import com.dialog.server.domain.Like;
+import com.dialog.server.domain.User;
+import com.dialog.server.repository.DiscussionRepository;
+import com.dialog.server.repository.LikeRepository;
+import com.dialog.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final DiscussionRepository discussionRepository;
+
+    @Transactional
+    public void create(Long userId, Long discussionId) {
+        User user = getUserById(userId);
+        Discussion discussion = getDiscussionById(discussionId);
+
+        if (likeRepository.existsByUserAndDiscussion(user, discussion)) {
+            throw new IllegalArgumentException("해당 토론에는 이미 좋아요한 상태입니다.");
+        }
+        Like like = Like.builder()
+                .user(user)
+                .discussion(discussion)
+                .build();
+        likeRepository.save(like);
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(userId + "에 해당하는 user를 찾을 수 없습니다."));
+    }
+
+    private Discussion getDiscussionById(Long discussionId) {
+        return discussionRepository.findById(discussionId)
+                .orElseThrow(() -> new IllegalArgumentException(discussionId + "에 해당하는 discussion을 찾을 수 없습니다."));
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -35,12 +35,14 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
     # spring jpa ??
-    jpa:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
       hibernate:
-        ddl-auto: create
-      properties:
-        hibernate:
-          dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
 
 ---
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -11,12 +11,14 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
     # spring jpa ??
-    jpa:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
       hibernate:
-        ddl-auto: update
-      properties:
-        hibernate:
-          dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
 
 ---
 
@@ -35,7 +37,7 @@ spring:
     # spring jpa ??
     jpa:
       hibernate:
-        ddl-auto: update
+        ddl-auto: create
       properties:
         hibernate:
           dialect: org.hibernate.dialect.MySQLDialect

--- a/server/src/test/java/com/dialog/server/service/LikeServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/LikeServiceTest.java
@@ -71,6 +71,22 @@ class LikeServiceTest {
                 .hasMessage("해당 토론에는 이미 좋아요한 상태입니다.");
     }
 
+    @Test
+    void 사용자는_토론에_대해_좋아요를_취소할_수_있다() {
+        //given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+        createLike(user, discussion);
+
+        //when
+        likeService.delete(user.getId(), discussion.getId());
+
+        //then
+        assertThat(likeRepository.findById(1L))
+                .isNotPresent();
+    }
+
+
     private User createUser() {
         User user = User.builder()
                 .email("email")

--- a/server/src/test/java/com/dialog/server/service/LikeServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/LikeServiceTest.java
@@ -1,0 +1,108 @@
+package com.dialog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dialog.server.domain.Category;
+import com.dialog.server.domain.Discussion;
+import com.dialog.server.domain.Like;
+import com.dialog.server.domain.User;
+import com.dialog.server.repository.DiscussionRepository;
+import com.dialog.server.repository.LikeRepository;
+import com.dialog.server.repository.UserRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class LikeServiceTest {
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private DiscussionRepository discussionRepository;
+
+    private LikeService likeService;
+
+    @BeforeEach
+    void setUp() {
+        likeService = new LikeService(likeRepository, userRepository, discussionRepository);
+    }
+
+    @Test
+    void 사용자는_토론에_좋아요를_할_수_있다() {
+        //given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+
+        //when
+        likeService.create(user.getId(), discussion.getId());
+
+        //then
+        Like createdLike = Like.builder()
+                .id(1L)
+                .discussion(discussion)
+                .user(user)
+                .build();
+        assertThat(likeRepository.findById(1L))
+                .isPresent()
+                .hasValue(createdLike);
+    }
+
+    @Test
+    void 좋아요를_할때_사용자가_토론에_이미_좋아요를_했다면_예외가_발생한다() {
+        //given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+        createLike(user, discussion);
+
+        //when
+        //then
+        assertThatThrownBy(() -> likeService.create(user.getId(), discussion.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 토론에는 이미 좋아요한 상태입니다.");
+    }
+
+    private User createUser() {
+        User user = User.builder()
+                .email("email")
+                .nickname("test")
+                .emailNotification(false)
+                .phoneNotification(false)
+                .phoneNumber("111-111-1111")
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Discussion createDiscussion(User user) {
+        Discussion discussion = Discussion.builder()
+                .author(user)
+                .category(Category.ANDROID)
+                .content("content")
+                .startAt(LocalDateTime.of(2025, 5, 15, 10, 1))
+                .endAt(LocalDateTime.of(2025, 5, 15, 11, 1))
+                .title("title")
+                .maxParticipantCount(3)
+                .participantCount(3)
+                .place("place")
+                .viewCount(3)
+                .build();
+        return discussionRepository.save(discussion);
+    }
+
+    private Like createLike(User user, Discussion discussion) {
+        Like like = Like.builder()
+                .user(user)
+                .discussion(discussion)
+                .build();
+        return likeRepository.save(like);
+    }
+}


### PR DESCRIPTION
토론에 대해서 좋아요, 좋아요 취소 API 구현했습니다. 
- 현재 로그인한 사용자의 id를 가져오는 방법이 없어 가짜 id인 1L을 사용중입니다. 
- 아직 예외 공통화를 하지 않아 일단은 서비스단에서 예외처리를 IllegalArgumentException을 이용해 구현해 놨습니다. 
- 서비스 테스트는 DataJpaTest 어노테이션을 이용해 통합 테스트를 진행했습니다. 

추가 논의 사항은 댓글로 작성해놓겠습니다:)

closed #6 