### PR TITLE
#15 토론 검색 기능 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation 'com.querydsl:querydsl-core:5.0.0'
 
 
 	runtimeOnly 'com.h2database:h2'
@@ -35,6 +37,9 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -43,4 +48,8 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+clean {
+	delete file('src/main/generated')
 }

--- a/server/src/main/java/com/dialog/server/config/JpaConfig.java
+++ b/server/src/main/java/com/dialog/server/config/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.dialog.server.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/server/src/main/java/com/dialog/server/controller/DiscussionController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionController.java
@@ -3,17 +3,26 @@ package com.dialog.server.controller;
 import com.dialog.server.dto.request.DiscussionCreateRequest;
 import com.dialog.server.dto.request.DiscussionCursorPageRequest;
 import com.dialog.server.dto.request.DiscussionUpdateRequest;
+import com.dialog.server.dto.request.SearchType;
 import com.dialog.server.dto.response.DiscussionCreateResponse;
 import com.dialog.server.dto.response.DiscussionCursorPageResponse;
 import com.dialog.server.dto.response.DiscussionDetailResponse;
+import com.dialog.server.dto.response.DiscussionSlotResponse;
 import com.dialog.server.exception.ApiSuccessResponse;
 import com.dialog.server.service.DiscussionService;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,6 +55,19 @@ public class DiscussionController {
         DiscussionCursorPageRequest request = new DiscussionCursorPageRequest(cursor, size, direction);
         DiscussionCursorPageResponse<DiscussionDetailResponse> pageDiscussions = discussionService.getDiscussionsWithDateCursor(request);
         return ResponseEntity.ok().body(new ApiSuccessResponse<>(pageDiscussions));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiSuccessResponse<DiscussionCursorPageResponse<DiscussionSlotResponse>>> searchDiscussions(
+            @RequestParam int searchBy,
+            @RequestParam String query,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false, defaultValue = "10") int size
+    ) {
+        final DiscussionCursorPageResponse<DiscussionSlotResponse> searched = discussionService.searchDiscussion(
+                SearchType.fromValue(searchBy), query, cursor, size
+        );
+        return ResponseEntity.ok().body(new ApiSuccessResponse<>(searched));
     }
 
     @PatchMapping("/{id}")

--- a/server/src/main/java/com/dialog/server/dto/request/SearchType.java
+++ b/server/src/main/java/com/dialog/server/dto/request/SearchType.java
@@ -1,0 +1,25 @@
+package com.dialog.server.dto.request;
+
+import com.dialog.server.exception.DialogException;
+import com.dialog.server.exception.ErrorCode;
+
+public enum SearchType {
+    TITLE_OR_CONTENT(0),
+    AUTHOR_NICKNAME(1),
+    ;
+
+    public final int value;
+
+    SearchType(int value) {
+        this.value = value;
+    }
+
+    public static SearchType fromValue(int value) {
+        for (SearchType type : values()) {
+            if (type.value == value) {
+                return type;
+            }
+        }
+        throw new DialogException(ErrorCode.INVALID_SEARCH_TYPE);
+    }
+}

--- a/server/src/main/java/com/dialog/server/dto/response/DiscussionSlotResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/response/DiscussionSlotResponse.java
@@ -1,0 +1,39 @@
+package com.dialog.server.dto.response;
+
+import com.dialog.server.domain.Category;
+import com.dialog.server.domain.Discussion;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+public record DiscussionSlotResponse(
+        Long id,
+        String title,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime startAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime endAt,
+        String place,
+        Category category,
+        int participantCount,
+        int maxParticipantCount,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        int viewCount
+) {
+
+    public static DiscussionSlotResponse from(Discussion discussion) {
+        return new DiscussionSlotResponse(
+                discussion.getId(),
+                discussion.getTitle(),
+                discussion.getStartAt(),
+                discussion.getEndAt(),
+                discussion.getPlace(),
+                discussion.getCategory(),
+                discussion.getParticipantCount(),
+                discussion.getMaxParticipantCount(),
+                discussion.getCreatedAt(),
+                discussion.getModifiedAt(),
+                discussion.getViewCount()
+        );
+    }
+}

--- a/server/src/main/java/com/dialog/server/exception/ErrorCode.java
+++ b/server/src/main/java/com/dialog/server/exception/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode {
     CREATE_DISCUSSION_FAILED("5025", "토론을 생성할 수 없습니다", HttpStatus.BAD_REQUEST),
     DISCUSSION_ALREADY_STARTED("5026", "이미 시작된 토론입니다.", HttpStatus.BAD_REQUEST),
     CANNOT_DELETE_DISCUSSION("5027", "삭제할 수 없는 토론입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_SEARCH_TYPE("5028", "유효하지 않은 검색 조건입니다.", HttpStatus.BAD_REQUEST),
+    PAGE_SIZE_TOO_LARGE("5029", "페이지의 크기는 50개가 최대입니다.", HttpStatus.BAD_REQUEST),
 
     USER_NOT_FOUND("5031", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     EXIST_USER_EMAIL("5032", "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),

--- a/server/src/main/java/com/dialog/server/repository/DiscussionCustomRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/DiscussionCustomRepository.java
@@ -1,0 +1,17 @@
+package com.dialog.server.repository;
+
+import com.dialog.server.domain.Discussion;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface DiscussionCustomRepository {
+
+    List<Discussion> findByTitleOrContentContainingPageable(String keyword, Pageable pageable);
+
+    List<Discussion> findByTitleOrContentContainingBeforeDateCursor(String keyword, LocalDateTime cursor, Long id, int limit);
+
+    List<Discussion> findByAuthorNicknameContainingPageable(String nickname, Pageable pageable);
+
+    List<Discussion> findByAuthorNicknameContainingBeforeDateCursor(String nickname, LocalDateTime cursor, Long id, int limit);
+}

--- a/server/src/main/java/com/dialog/server/repository/DiscussionCustomRepositoryImpl.java
+++ b/server/src/main/java/com/dialog/server/repository/DiscussionCustomRepositoryImpl.java
@@ -1,0 +1,109 @@
+package com.dialog.server.repository;
+
+import com.dialog.server.domain.Discussion;
+import com.dialog.server.domain.QDiscussion;
+import com.dialog.server.domain.QUser;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class DiscussionCustomRepositoryImpl implements DiscussionCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QDiscussion discussion = QDiscussion.discussion;
+    private final QUser user = QUser.user;
+
+    @Override
+    public List<Discussion> findByTitleOrContentContainingPageable(String keyword, Pageable pageable) {
+        return queryFactory.selectFrom(discussion)
+                .innerJoin(discussion.author, user)
+                .fetchJoin()
+                .where(
+                        titleOrContentContains(keyword)
+                )
+                .orderBy(discussion.createdAt.desc(), discussion.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public List<Discussion> findByTitleOrContentContainingBeforeDateCursor(String keyword,
+                                                                           LocalDateTime cursor,
+                                                                           Long cursorId,
+                                                                           int limit) {
+        return queryFactory.selectFrom(discussion)
+                .innerJoin(discussion.author, user)
+                .fetchJoin()
+                .where(
+                        titleOrContentContains(keyword),
+                        cursorBefore(cursor, cursorId)
+                )
+                .orderBy(discussion.createdAt.desc(), discussion.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    private BooleanExpression titleOrContentContains(String keyword) {
+        if (!hasText(keyword)) {
+            return null;
+        }
+        final String trimmed = keyword.trim();
+        return discussion.title.containsIgnoreCase(trimmed)
+                .or(discussion.content.containsIgnoreCase(trimmed));
+    }
+
+    @Override
+    public List<Discussion> findByAuthorNicknameContainingPageable(String nickname, Pageable pageable) {
+        return queryFactory.selectFrom(discussion)
+                .innerJoin(discussion.author, user)
+                .fetchJoin()
+                .where(
+                        nicknameContains(nickname)
+                )
+                .orderBy(discussion.createdAt.desc(), discussion.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public List<Discussion> findByAuthorNicknameContainingBeforeDateCursor(String nickname,
+                                                                           LocalDateTime cursor,
+                                                                           Long cursorId,
+                                                                           int limit) {
+        return queryFactory.selectFrom(discussion)
+                .innerJoin(discussion.author, user)
+                .fetchJoin()
+                .where(
+                        nicknameContains(nickname),
+                        cursorBefore(cursor, cursorId)
+                )
+                .orderBy(discussion.createdAt.desc(), discussion.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    private BooleanExpression nicknameContains(String nickname) {
+        return nickname != null ? user.nickname.containsIgnoreCase(nickname) : null;
+    }
+
+    private boolean hasText(String text) {
+        return text != null && !text.isBlank();
+    }
+
+    private BooleanExpression cursorBefore(LocalDateTime cursor, Long cursorId) {
+        if (cursor == null || cursorId == null) {
+            return null;
+        }
+
+        return discussion.createdAt.loe(cursor)
+                .or(discussion.createdAt.eq(cursor).and(discussion.id.gt(cursorId)));
+    }
+}

--- a/server/src/main/java/com/dialog/server/repository/DiscussionRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/DiscussionRepository.java
@@ -1,20 +1,19 @@
 package com.dialog.server.repository;
 
 import com.dialog.server.domain.Discussion;
-import org.springframework.data.domain.Pageable;
 import jakarta.persistence.LockModeType;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.stereotype.Repository;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
+public interface DiscussionRepository extends JpaRepository<Discussion, Long>, DiscussionCustomRepository {
 
     @Query("""
         SELECT d
@@ -56,6 +55,7 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
 
     @Query("SELECT COUNT(d) > 0 FROM Discussion d WHERE d.createdAt > :cursor OR (d.createdAt = :cursor AND d.id > :id)")
     boolean existsDiscussionsAfterDateCursor(@Param("cursor") LocalDateTime cursor, @Param("id") Long id);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT d FROM Discussion d WHERE d.id = :id")
     Optional<Discussion> findByIdForUpdate(@Param("id") Long id);

--- a/server/src/main/java/com/dialog/server/service/DiscussionService.java
+++ b/server/src/main/java/com/dialog/server/service/DiscussionService.java
@@ -119,7 +119,7 @@ public class DiscussionService {
         switch (searchType) {
             case TITLE_OR_CONTENT -> discussions = searchDiscussionByTitleOrContent(query, cursor, size);
             case AUTHOR_NICKNAME -> discussions = searchDiscussionByAuthorNickname(query, cursor, size);
-            default -> throw new DialogException(ErrorCode.BAD_REQUEST);
+            default -> throw new DialogException(ErrorCode.INVALID_SEARCH_TYPE);
         }
         return buildDateCursorResponseV2(discussions, size, cursor);
     }

--- a/server/src/main/java/com/dialog/server/service/DiscussionService.java
+++ b/server/src/main/java/com/dialog/server/service/DiscussionService.java
@@ -111,10 +111,7 @@ public class DiscussionService {
                                                                                  String query,
                                                                                  String cursor,
                                                                                  int size) {
-        if (size > MAX_PAGE_SIZE) {
-            throw new DialogException(ErrorCode.PAGE_SIZE_TOO_LARGE);
-        }
-
+        validatePageSize(size);
         List<Discussion> discussions;
         switch (searchType) {
             case TITLE_OR_CONTENT -> discussions = searchDiscussionByTitleOrContent(query, cursor, size);
@@ -122,6 +119,12 @@ public class DiscussionService {
             default -> throw new DialogException(ErrorCode.INVALID_SEARCH_TYPE);
         }
         return buildDateCursorResponseV2(discussions, size, cursor);
+    }
+
+    private static void validatePageSize(int size) {
+        if (size > MAX_PAGE_SIZE) {
+            throw new DialogException(ErrorCode.PAGE_SIZE_TOO_LARGE);
+        }
     }
 
     private List<Discussion> searchDiscussionByTitleOrContent(String query,

--- a/server/src/test/java/com/dialog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.dialog.server.config.JpaConfig;
 import com.dialog.server.domain.Role;
 import com.dialog.server.domain.User;
 import com.dialog.server.dto.auth.request.SignupRequest;
@@ -15,9 +16,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.context.ActiveProfiles;
 
+@Import(JpaConfig.class)
 @DataJpaTest
 @ActiveProfiles("test")
 class AuthServiceTest {

--- a/server/src/test/java/com/dialog/server/service/CustomOAuth2UserServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/CustomOAuth2UserServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.dialog.server.config.JpaConfig;
 import com.dialog.server.domain.Role;
 import com.dialog.server.domain.User;
 import com.dialog.server.dto.security.OAuth2UserPrincipal;
@@ -25,7 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles("test")
-@Import({CustomOAuth2UserService.class})
+@Import({CustomOAuth2UserService.class, JpaConfig.class})
 @DataJpaTest
 class CustomOAuth2UserServiceTest {
 

--- a/server/src/test/java/com/dialog/server/service/DiscussionParticipantServiceConcurrencyTest.java
+++ b/server/src/test/java/com/dialog/server/service/DiscussionParticipantServiceConcurrencyTest.java
@@ -3,6 +3,7 @@ package com.dialog.server.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import com.dialog.server.config.JpaConfig;
 import com.dialog.server.domain.Category;
 import com.dialog.server.domain.Discussion;
 import com.dialog.server.domain.User;
@@ -22,8 +23,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+@Import(JpaConfig.class)
 @ActiveProfiles("test")
 @SpringBootTest
 class DiscussionParticipantServiceConcurrencyTest {

--- a/server/src/test/java/com/dialog/server/service/DiscussionParticipantServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/DiscussionParticipantServiceTest.java
@@ -3,6 +3,7 @@ package com.dialog.server.service;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import com.dialog.server.config.JpaConfig;
 import com.dialog.server.domain.Category;
 import com.dialog.server.domain.Discussion;
 import com.dialog.server.domain.User;
@@ -14,8 +15,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+@Import(JpaConfig.class)
 @ActiveProfiles("test")
 @DataJpaTest
 class DiscussionParticipantServiceTest {

--- a/server/src/test/java/com/dialog/server/service/LikeServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/LikeServiceTest.java
@@ -3,6 +3,7 @@ package com.dialog.server.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.dialog.server.config.JpaConfig;
 import com.dialog.server.domain.Category;
 import com.dialog.server.domain.Discussion;
 import com.dialog.server.domain.Like;
@@ -17,8 +18,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+@Import(JpaConfig.class)
 @ActiveProfiles("test")
 @DataJpaTest
 class LikeServiceTest {

--- a/server/src/test/java/com/dialog/server/service/ScrapServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/ScrapServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
+import com.dialog.server.config.JpaConfig;
 import com.dialog.server.domain.Category;
 import com.dialog.server.domain.Discussion;
 import com.dialog.server.domain.Scrap;
@@ -18,8 +19,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+@Import(JpaConfig.class)
 @ActiveProfiles("test")
 @DataJpaTest
 class ScrapServiceTest {


### PR DESCRIPTION
토론 검색 기능을 구현하였습니다.

**QueryDsl을 도입한 결과 아래와 같이 설정을 해주세요**  @abc5259 @kwonkeonhyeong 
- Setting > Build, Execution, Deployment > Build Tools > Gradle > Build and Run 에서 IntelliJ가 아닌 Gradle로 빌드하게 설정하기
- Gradle > Tasks > other 에서 compileJava 실행하기
  - `build/generated/annotationProcessor/java/main/com/server/domain`에 Q클래스들이 존재하면 컴파일을 하지 않아도 됩니다.

this closes #15 

### 고쳐야 할 것 
@kwonkeonhyeong 

- 커서를 이용한 검색 구현 시 prev는 필요가 없어 prev가 없는`DiscussionService#buildDateCursorResponseV2`를 만들었습니다. 기존의 version1에서 대체하여주세요!
- cursor를 파싱하는 부분을 히포의 것을 복사해서 사용하였는데, 중복된 로직이 많네요! 여유가 되신다면 메서드 분리를 부탁드려요!