### PR TITLE
#26 CORS 관련 설정 및 개발 단계에서 권한 인증 완화

### DIFF
--- a/server/src/main/java/com/dialog/server/config/CorsConfig.java
+++ b/server/src/main/java/com/dialog/server/config/CorsConfig.java
@@ -1,0 +1,28 @@
+package com.dialog.server.config;
+
+import java.util.Arrays;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/server/src/main/java/com/dialog/server/config/WebSecurityConfig.java
+++ b/server/src/main/java/com/dialog/server/config/WebSecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 @RequiredArgsConstructor
 @Configuration
@@ -19,21 +20,26 @@ public class WebSecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/api/signup", "/api/signup/check").permitAll()
-                        .anyRequest().authenticated()
+                                // TODO: 개발 완료 시 아래 행 삭제
+                                .anyRequest().permitAll()
+                        // TODO: 개발 완료 시 아래 주석 해제
+//                        .requestMatchers("/", "/api/signup", "/api/signup/check").permitAll()
+//                        .anyRequest().authenticated()
                 )
                 .oauth2Login(oAuth2LoginConfigurer -> oAuth2LoginConfigurer
                         .successHandler(oAuth2SuccessHandler)
                         .failureHandler(oAuth2FailureHandler)
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService)
-                )
-        );
+                        )
+                );
         return http.build();
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/handler/OAuth2FailureHandler.java
+++ b/server/src/main/java/com/dialog/server/controller/handler/OAuth2FailureHandler.java
@@ -3,6 +3,7 @@ package com.dialog.server.controller.handler;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -10,9 +11,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
+    @Value("${app.frontend.url}")
+    private String frontendUrl;
+
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
-        getRedirectStrategy().sendRedirect(request, response, "/"); // TODO: 추후 에러 처리 방식에 따라 변경
+        String homeRedirectUrl = frontendUrl + "/";
+        getRedirectStrategy().sendRedirect(request, response, homeRedirectUrl);
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/handler/OAuth2SuccessHandler.java
+++ b/server/src/main/java/com/dialog/server/controller/handler/OAuth2SuccessHandler.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -23,6 +24,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public static final String PENDING_OAUTH_ID = "pending_oauth_id";
 
     private final AuthService authService;
+
+    @Value("${app.frontend.url}")
+    private String frontendUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -42,7 +46,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         setAuthenticationInSession(request, authentication);
 
-        getRedirectStrategy().sendRedirect(request, response, HOME_PATH);
+        String redirectUrl = frontendUrl + HOME_PATH;
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }
 
     private void handleUnregisteredUser(HttpServletRequest request, HttpServletResponse response,
@@ -50,7 +55,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         HttpSession session = request.getSession(true);
         session.setAttribute(PENDING_OAUTH_ID, principal.getName());
 
-        getRedirectStrategy().sendRedirect(request, response, SIGNUP_PATH);
+        String redirectUrl = frontendUrl + SIGNUP_PATH;
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }
 
     private void setAuthenticationInSession(HttpServletRequest request, Authentication authentication) {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -47,6 +47,10 @@ spring:
             client-id: ${GITHUB_OAUTH_CLIENT_ID}
             client-secret: ${GITHUB_OAUTH_CLIENT_SECRET}
 
+app:
+  frontend:
+    url: http://localhost:5173
+
 ---
 
 spring:
@@ -77,3 +81,7 @@ spring:
   h2:
     console:
       enabled: true
+
+app:
+  frontend:
+    url: http://localhost:5173


### PR DESCRIPTION
## 작업 사유
프론트엔드 개발 환경 구축 및 개발 편의성 향상을 위한 설정 작업을 진행했습니다.

- CORS 문제 해결: 프론트엔드(`localhost:5173`)와 백엔드(`localhost:8080`) 간 통신을 위해 CORS 설정이 필요했습니다.
- OAuth 리다이렉트 문제 해결: 현재 OAuth 핸들러가 백엔드 주소로 리다이렉트하고 있어, 프론트엔드로 정상적인 리다이렉트가 되지 않는 문제가 있었습니다.
- 개발 편의성 향상: 프론트엔드 로그인 기능이 아직 미완성 상태이므로, 개발 단계에서는 인증을 임시로 해제하여 개발 효율성을 높이고자 했습니다.

## 변경사항
1. CORS 설정 추가

- `CorsConfig` 클래스 생성

2. 프론트엔드 URL 설정 관리

- `application.yml`에 프론트엔드 주소 설정 추가 (app.frontend.url)
- `@Value` 어노테이션을 통해 설정값 주입

3. OAuth 핸들러 수정

- `OAuth2SuccessHandler`: 프론트엔드 주소로 리다이렉트하도록 수정
- `OAuth2FailureHandler`: 프론트엔드 주소로 리다이렉트하도록 수정

4. 개발 단계 인증 해제

- `WebSecurityConfig`에서 모든 요청을 `permitAll()`로 설정
- 기존 인증 설정은 주석 처리하고 TODO 주석으로 개발 완료 후 복원 가이드 추가

this closes #26 