### PR TITLE
인증된 사용자 ID 추출 로직 개선 및 프로필 사진 구현

### DIFF
--- a/server/src/main/java/com/dialog/server/config/WebMvcConfig.java
+++ b/server/src/main/java/com/dialog/server/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.dialog.server.config;
+
+import com.dialog.server.controller.resolver.AuthenticatedUserIdArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final AuthenticatedUserIdArgumentResolver authenticatedUserIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedUserIdArgumentResolver);
+    }
+}

--- a/server/src/main/java/com/dialog/server/controller/AuthController.java
+++ b/server/src/main/java/com/dialog/server/controller/AuthController.java
@@ -45,7 +45,7 @@ public class AuthController {
         final String oauthId = extractOAuthIdFromSession(request);
         Long userId = authService.registerUser(signupRequest, oauthId);
 
-        final Authentication authentication = authService.authenticate(oauthId);
+        final Authentication authentication = authService.authenticate(userId);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         HttpSession session = request.getSession(true);
@@ -55,7 +55,7 @@ public class AuthController {
     }
 
     @GetMapping("/login/check")
-    public ResponseEntity<ApiSuccessResponse<LoginCheckResponse>> checkLogin(HttpServletRequest request) {
+    public ResponseEntity<ApiSuccessResponse<LoginCheckResponse>> checkLogin() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         boolean isLoggedIn = false;

--- a/server/src/main/java/com/dialog/server/controller/DiscussionController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionController.java
@@ -1,5 +1,6 @@
 package com.dialog.server.controller;
 
+import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.dto.request.DiscussionCreateRequest;
 import com.dialog.server.dto.request.DiscussionCursorPageRequest;
 import com.dialog.server.dto.request.DiscussionUpdateRequest;
@@ -13,7 +14,6 @@ import com.dialog.server.service.DiscussionService;
 import com.dialog.server.service.NotificationService;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,8 +35,7 @@ public class DiscussionController {
     private final NotificationService notificationService;
 
     @PostMapping
-    public ResponseEntity<ApiSuccessResponse<DiscussionCreateResponse>> postDiscussion(@RequestBody @Valid DiscussionCreateRequest request, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<ApiSuccessResponse<DiscussionCreateResponse>> postDiscussion(@RequestBody @Valid DiscussionCreateRequest request, @AuthenticatedUserId Long userId) {
         DiscussionCreateResponse response = discussionService.createDiscussion(request, userId);
         final URI uri = URI.create("/api/discussions/" + response.discussionId());
         notificationService.sendDiscussionCreatedNotification(userId, uri.getRawPath());

--- a/server/src/main/java/com/dialog/server/controller/DiscussionController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionController.java
@@ -36,10 +36,10 @@ public class DiscussionController {
 
     @PostMapping
     public ResponseEntity<ApiSuccessResponse<DiscussionCreateResponse>> postDiscussion(@RequestBody @Valid DiscussionCreateRequest request, Principal principal) {
-        String oauthId = principal.getName();
-        DiscussionCreateResponse response = discussionService.createDiscussion(request, oauthId);
+        Long userId = Long.valueOf(principal.getName());
+        DiscussionCreateResponse response = discussionService.createDiscussion(request, userId);
         final URI uri = URI.create("/api/discussions/" + response.discussionId());
-        notificationService.sendDiscussionCreatedNotification(oauthId, uri.getRawPath());
+        notificationService.sendDiscussionCreatedNotification(userId, uri.getRawPath());
         return ResponseEntity.created(uri)
                 .body(new ApiSuccessResponse<>(response));
     }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
@@ -1,6 +1,7 @@
 package com.dialog.server.controller;
 
 import com.dialog.server.service.LikeService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,20 +15,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DiscussionLikeController {
 
-    private static final Long FAKE_USER_ID = 1L;
-
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<Void> likeDiscussion(@PathVariable("discussionsId") Long discussionsId) {
-        likeService.create(FAKE_USER_ID, discussionsId);
+    public ResponseEntity<Void> likeDiscussion(@PathVariable("discussionsId") Long discussionsId, Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+        likeService.create(userId, discussionsId);
         return ResponseEntity.ok()
                 .build();
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteLikeDiscussion(@PathVariable("discussionsId") Long discussionsId) {
-        likeService.delete(FAKE_USER_ID, discussionsId);
+    public ResponseEntity<Void> deleteLikeDiscussion(@PathVariable("discussionsId") Long discussionsId, Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+        likeService.delete(userId, discussionsId);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
@@ -1,7 +1,7 @@
 package com.dialog.server.controller;
 
+import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.service.LikeService;
-import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,16 +18,14 @@ public class DiscussionLikeController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<Void> likeDiscussion(@PathVariable("discussionsId") Long discussionsId, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<Void> likeDiscussion(@PathVariable("discussionsId") Long discussionsId, @AuthenticatedUserId Long userId) {
         likeService.create(userId, discussionsId);
         return ResponseEntity.ok()
                 .build();
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteLikeDiscussion(@PathVariable("discussionsId") Long discussionsId, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<Void> deleteLikeDiscussion(@PathVariable("discussionsId") Long discussionsId, @AuthenticatedUserId Long userId) {
         likeService.delete(userId, discussionsId);
         return ResponseEntity.noContent()
                 .build();

--- a/server/src/main/java/com/dialog/server/controller/DiscussionParticipantController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionParticipantController.java
@@ -1,6 +1,7 @@
 package com.dialog.server.controller;
 
 import com.dialog.server.service.DiscussionParticipantService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,13 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DiscussionParticipantController {
 
-    private static final Long FAKE_USER_ID = 1L;
-
     private final DiscussionParticipantService discussionParticipantService;
 
     @PostMapping
-    public ResponseEntity<Void> participate(@PathVariable("discussionId") Long discussionId) {
-        discussionParticipantService.participate(FAKE_USER_ID, discussionId);
+    public ResponseEntity<Void> participate(@PathVariable("discussionId") Long discussionId, Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+        discussionParticipantService.participate(userId, discussionId);
         return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionParticipantController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionParticipantController.java
@@ -1,7 +1,7 @@
 package com.dialog.server.controller;
 
+import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.service.DiscussionParticipantService;
-import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,8 +17,7 @@ public class DiscussionParticipantController {
     private final DiscussionParticipantService discussionParticipantService;
 
     @PostMapping
-    public ResponseEntity<Void> participate(@PathVariable("discussionId") Long discussionId, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<Void> participate(@PathVariable("discussionId") Long discussionId, @AuthenticatedUserId Long userId) {
         discussionParticipantService.participate(userId, discussionId);
         return ResponseEntity.ok().build();
     }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
@@ -1,7 +1,7 @@
 package com.dialog.server.controller;
 
+import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.service.ScrapService;
-import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,16 +19,14 @@ public class DiscussionScrapController {
     private final ScrapService scrapService;
 
     @PostMapping
-    public ResponseEntity<Void> scrap(@PathVariable Long discussionId, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<Void> scrap(@PathVariable Long discussionId, @AuthenticatedUserId Long userId) {
         scrapService.create(userId, discussionId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteScrap(@PathVariable Long discussionId, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<Void> deleteScrap(@PathVariable Long discussionId, @AuthenticatedUserId Long userId) {
         scrapService.delete(userId, discussionId);
         return ResponseEntity.noContent()
                 .build();

--- a/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
@@ -1,6 +1,7 @@
 package com.dialog.server.controller;
 
 import com.dialog.server.service.ScrapService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,20 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DiscussionScrapController {
 
-    private static final Long FAKE_USER_ID = 1L;
-
     private final ScrapService scrapService;
 
     @PostMapping
-    public ResponseEntity<Void> scrap(@PathVariable Long discussionId) {
-        scrapService.create(FAKE_USER_ID, discussionId);
+    public ResponseEntity<Void> scrap(@PathVariable Long discussionId, Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+        scrapService.create(userId, discussionId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteScrap(@PathVariable Long discussionId) {
-        scrapService.delete(FAKE_USER_ID, discussionId);
+    public ResponseEntity<Void> deleteScrap(@PathVariable Long discussionId, Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+        scrapService.delete(userId, discussionId);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/server/src/main/java/com/dialog/server/controller/FirebaseTokenController.java
+++ b/server/src/main/java/com/dialog/server/controller/FirebaseTokenController.java
@@ -27,13 +27,15 @@ public class FirebaseTokenController {
 
     @GetMapping
     public ResponseEntity<ApiSuccessResponse<List<MyTokenResponse>>> getMyTokens(Principal principal) {
-        final List<MyTokenResponse> tokens = notificationService.getMessagingTokensByUserId(principal.getName());
+        Long userId = Long.valueOf(principal.getName());
+        final List<MyTokenResponse> tokens = notificationService.getMessagingTokensByUserId(userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(tokens));
     }
 
     @PostMapping
     public ResponseEntity<ApiSuccessResponse<TokenCreationResponse>> addToken(@RequestBody TokenRequest tokenRequest, Principal principal) {
-        final TokenCreationResponse response = notificationService.addMessagingToken(principal.getName(), tokenRequest.token());
+        Long userId = Long.valueOf(principal.getName());
+        final TokenCreationResponse response = notificationService.addMessagingToken(userId, tokenRequest.token());
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }
 
@@ -45,7 +47,8 @@ public class FirebaseTokenController {
 
     @PatchMapping("/{tokenId}")
     public ResponseEntity<Void> updateToken(@PathVariable Long tokenId, TokenRequest tokenRequest, Principal principal) {
-        notificationService.updateToken(principal.getName(), tokenId, tokenRequest.token());
+        Long userId = Long.valueOf(principal.getName());
+        notificationService.updateToken(userId, tokenId, tokenRequest.token());
         return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/FirebaseTokenController.java
+++ b/server/src/main/java/com/dialog/server/controller/FirebaseTokenController.java
@@ -1,11 +1,11 @@
 package com.dialog.server.controller;
 
+import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.dto.notification.request.TokenRequest;
 import com.dialog.server.dto.notification.resposne.MyTokenResponse;
 import com.dialog.server.dto.notification.resposne.TokenCreationResponse;
 import com.dialog.server.exception.ApiSuccessResponse;
 import com.dialog.server.service.NotificationService;
-import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,15 +26,13 @@ public class FirebaseTokenController {
     private final NotificationService notificationService;
 
     @GetMapping
-    public ResponseEntity<ApiSuccessResponse<List<MyTokenResponse>>> getMyTokens(Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<ApiSuccessResponse<List<MyTokenResponse>>> getMyTokens(@AuthenticatedUserId Long userId) {
         final List<MyTokenResponse> tokens = notificationService.getMessagingTokensByUserId(userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(tokens));
     }
 
     @PostMapping
-    public ResponseEntity<ApiSuccessResponse<TokenCreationResponse>> addToken(@RequestBody TokenRequest tokenRequest, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<ApiSuccessResponse<TokenCreationResponse>> addToken(@RequestBody TokenRequest tokenRequest, @AuthenticatedUserId Long userId) {
         final TokenCreationResponse response = notificationService.addMessagingToken(userId, tokenRequest.token());
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }
@@ -46,8 +44,7 @@ public class FirebaseTokenController {
     }
 
     @PatchMapping("/{tokenId}")
-    public ResponseEntity<Void> updateToken(@PathVariable Long tokenId, TokenRequest tokenRequest, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<Void> updateToken(@PathVariable Long tokenId, TokenRequest tokenRequest, @AuthenticatedUserId Long userId) {
         notificationService.updateToken(userId, tokenId, tokenRequest.token());
         return ResponseEntity.ok().build();
     }

--- a/server/src/main/java/com/dialog/server/controller/UserController.java
+++ b/server/src/main/java/com/dialog/server/controller/UserController.java
@@ -6,6 +6,7 @@ import com.dialog.server.dto.auth.response.UserInfoResponse;
 import com.dialog.server.exception.ApiSuccessResponse;
 import com.dialog.server.service.UserService;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,8 +14,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.security.Principal;
 
 @RequestMapping("/api/user")
 @RestController
@@ -25,15 +24,15 @@ public class UserController {
 
     @GetMapping("/mine")
     public ResponseEntity<ApiSuccessResponse<UserInfoResponse>> getUserInfo(Principal principal) {
-        String oauthId = principal.getName();
-        UserInfoResponse response = userService.getUserInfo(oauthId);
+        Long userId = Long.valueOf(principal.getName());
+        UserInfoResponse response = userService.getUserInfo(userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }
 
     @PatchMapping("/mine/notifications")
     public ResponseEntity<ApiSuccessResponse<NotificationSettingResponse>> patchNotification(@RequestBody @Valid NotificationSettingRequest request, Principal principal) {
-        String oauthId = principal.getName();
-        NotificationSettingResponse response = userService.updateNotification(request, oauthId);
+        Long userId = Long.valueOf(principal.getName());
+        NotificationSettingResponse response = userService.updateNotification(request, userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/UserController.java
+++ b/server/src/main/java/com/dialog/server/controller/UserController.java
@@ -1,12 +1,12 @@
 package com.dialog.server.controller;
 
+import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.dto.auth.request.NotificationSettingRequest;
 import com.dialog.server.dto.auth.response.NotificationSettingResponse;
 import com.dialog.server.dto.auth.response.UserInfoResponse;
 import com.dialog.server.exception.ApiSuccessResponse;
 import com.dialog.server.service.UserService;
 import jakarta.validation.Valid;
-import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,15 +23,13 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/mine")
-    public ResponseEntity<ApiSuccessResponse<UserInfoResponse>> getUserInfo(Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<ApiSuccessResponse<UserInfoResponse>> getUserInfo(@AuthenticatedUserId Long userId) {
         UserInfoResponse response = userService.getUserInfo(userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }
 
     @PatchMapping("/mine/notifications")
-    public ResponseEntity<ApiSuccessResponse<NotificationSettingResponse>> patchNotification(@RequestBody @Valid NotificationSettingRequest request, Principal principal) {
-        Long userId = Long.valueOf(principal.getName());
+    public ResponseEntity<ApiSuccessResponse<NotificationSettingResponse>> patchNotification(@RequestBody @Valid NotificationSettingRequest request, @AuthenticatedUserId Long userId) {
         NotificationSettingResponse response = userService.updateNotification(request, userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }

--- a/server/src/main/java/com/dialog/server/controller/handler/OAuth2SuccessHandler.java
+++ b/server/src/main/java/com/dialog/server/controller/handler/OAuth2SuccessHandler.java
@@ -42,7 +42,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private void handleRegisteredUser(HttpServletRequest request, HttpServletResponse response,
                                       OAuth2UserPrincipal principal) throws IOException {
-        final Authentication authentication = authService.authenticate(principal.user().getOauthId());
+        final Authentication authentication = authService.authenticate(principal.user().getId());
 
         setAuthenticationInSession(request, authentication);
 

--- a/server/src/main/java/com/dialog/server/controller/resolver/AuthenticatedUserIdArgumentResolver.java
+++ b/server/src/main/java/com/dialog/server/controller/resolver/AuthenticatedUserIdArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.dialog.server.controller.resolver;
+
+import com.dialog.server.dto.auth.AuthenticatedUserId;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+@Component
+public class AuthenticatedUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticatedUserId.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            throw new IllegalStateException("Authentication not found"); // TODO 예외 고치기
+        }
+
+        try {
+            return Long.valueOf(authentication.getName());
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("Cannot extract user ID from authentication", e); // TODO 예외 고치기
+        }
+    }
+}

--- a/server/src/main/java/com/dialog/server/controller/resolver/AuthenticatedUserIdArgumentResolver.java
+++ b/server/src/main/java/com/dialog/server/controller/resolver/AuthenticatedUserIdArgumentResolver.java
@@ -1,7 +1,8 @@
 package com.dialog.server.controller.resolver;
 
 import com.dialog.server.dto.auth.AuthenticatedUserId;
-import lombok.extern.slf4j.Slf4j;
+import com.dialog.server.exception.DialogException;
+import com.dialog.server.exception.ErrorCode;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,7 +12,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-@Slf4j
 @Component
 public class AuthenticatedUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -29,13 +29,13 @@ public class AuthenticatedUserIdArgumentResolver implements HandlerMethodArgumen
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null) {
-            throw new IllegalStateException("Authentication not found"); // TODO 예외 고치기
+            throw new DialogException(ErrorCode.AUTHENTICATION_NOT_FOUND);
         }
 
         try {
             return Long.valueOf(authentication.getName());
         } catch (NumberFormatException e) {
-            throw new IllegalStateException("Cannot extract user ID from authentication", e); // TODO 예외 고치기
+            throw new DialogException(ErrorCode.INVALID_USER_ID_FORMAT, e);
         }
     }
 }

--- a/server/src/main/java/com/dialog/server/domain/ProfileImage.java
+++ b/server/src/main/java/com/dialog/server/domain/ProfileImage.java
@@ -1,0 +1,74 @@
+package com.dialog.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "profile_image")
+@Entity
+public class ProfileImage extends BaseEntity {
+
+    @Column(name = "profile_image_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+    private String originalFileName;
+    private String storedFileName;
+    private String filePath;
+    @Column(nullable = false)
+    private String accessUrl;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    private ProfileImage(
+            String filePath,
+            String originalFileName,
+            String storedFileName,
+            String accessUrl,
+            User user
+    ) {
+        this.filePath = filePath;
+        this.originalFileName = originalFileName;
+        this.storedFileName = storedFileName;
+        this.accessUrl = accessUrl;
+        this.user = user;
+    }
+
+    public void updateProfileImage(
+            String filePath,
+            String originalFileName,
+            String storedFileName,
+            String accessUrl
+    ) {
+        this.filePath = filePath;
+        this.originalFileName = originalFileName;
+        this.storedFileName = storedFileName;
+        this.accessUrl = accessUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ProfileImage that)) return false;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/server/src/main/java/com/dialog/server/dto/auth/AuthenticatedUserId.java
+++ b/server/src/main/java/com/dialog/server/dto/auth/AuthenticatedUserId.java
@@ -1,0 +1,11 @@
+package com.dialog.server.dto.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUserId {
+}

--- a/server/src/main/java/com/dialog/server/dto/security/GitHubOAuth2UserInfo.java
+++ b/server/src/main/java/com/dialog/server/dto/security/GitHubOAuth2UserInfo.java
@@ -8,6 +8,7 @@ public class GitHubOAuth2UserInfo {
 
     public static final String ID_PARAM = "id";
     public static final String EMAIL_PARAM = "email";
+    public static final String IMAGE_URL_PARAM = "avatar_url";
 
     private final Map<String, Object> attributes;
 
@@ -29,5 +30,10 @@ public class GitHubOAuth2UserInfo {
     public String getEmail() {
         Object email = attributes.get(EMAIL_PARAM);
         return email == null ? null : email.toString();
+    }
+
+    public String getProfileImageUrl() {
+        Object url = attributes.get(IMAGE_URL_PARAM);
+        return url == null ? null : url.toString();
     }
 }

--- a/server/src/main/java/com/dialog/server/exception/ErrorCode.java
+++ b/server/src/main/java/com/dialog/server/exception/ErrorCode.java
@@ -9,6 +9,8 @@ public enum ErrorCode {
      */
     GITHUB_USER_ID_MISSING("1001", "GitHub에서 사용자 ID를 가져올 수 없습니다.", HttpStatus.BAD_GATEWAY),
     INVALID_SIGNUP("1002", "유효하지 않은 회원가입입니다.", HttpStatus.UNAUTHORIZED),
+    AUTHENTICATION_NOT_FOUND("1003", "인증 정보를 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_USER_ID_FORMAT("1004", "유효하지 않은 인증 정보입니다.", HttpStatus.BAD_REQUEST),
 
     /**
      * 5XXX - 비즈니스 로직 관련
@@ -34,6 +36,9 @@ public enum ErrorCode {
     EXIST_USER_EMAIL("5032", "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
     REGISTERED_USER("5033", "이미 회원가입한 회원입니다.", HttpStatus.BAD_REQUEST),
     NOT_REGISTERED_USER("5034", "회원가입하지 않은 회원입니다.", HttpStatus.BAD_REQUEST),
+
+    MESSAGING_TOKEN_NOT_FOUND("5041", "메시징 토큰을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_TOKEN_ACCESS("5042", "토큰에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
     ;
 
     public final String code;

--- a/server/src/main/java/com/dialog/server/repository/ProfileImageRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/ProfileImageRepository.java
@@ -1,0 +1,10 @@
+package com.dialog.server.repository;
+
+import com.dialog.server.domain.ProfileImage;
+import com.dialog.server.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+    Optional<ProfileImage> findByUser(User user);
+}

--- a/server/src/main/java/com/dialog/server/service/AuthService.java
+++ b/server/src/main/java/com/dialog/server/service/AuthService.java
@@ -47,15 +47,15 @@ public class AuthService {
         return user.getEmail();
     }
 
-    public Authentication authenticate(String oauthId) {
-        User user = userRepository.findUserByOauthId(oauthId)
+    public Authentication authenticate(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
         if (user.getRole() == null || !user.isRegistered()) {
             throw new DialogException(ErrorCode.NOT_REGISTERED_USER);
         }
 
         return new UsernamePasswordAuthenticationToken(
-                oauthId,
+                userId,
                 null, // OAuth 로그인만 허용하므로 비밀번호 없음
                 user.getRole().toAuthorities()
         );

--- a/server/src/main/java/com/dialog/server/service/CustomOAuth2UserService.java
+++ b/server/src/main/java/com/dialog/server/service/CustomOAuth2UserService.java
@@ -1,12 +1,8 @@
 package com.dialog.server.service;
 
-import com.dialog.server.domain.ProfileImage;
-import com.dialog.server.domain.Role;
 import com.dialog.server.domain.User;
 import com.dialog.server.dto.security.GitHubOAuth2UserInfo;
 import com.dialog.server.dto.security.OAuth2UserPrincipal;
-import com.dialog.server.repository.ProfileImageRepository;
-import com.dialog.server.repository.UserRepository;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -14,21 +10,17 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
-    private final UserRepository userRepository;
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> defaultOAuth2UserService;
-    private final ProfileImageRepository profileImageRepository;
+    private final UserService userService;
 
-    public CustomOAuth2UserService(UserRepository userRepository,
-                                   @Qualifier("defaultOAuth2UserService") OAuth2UserService<OAuth2UserRequest, OAuth2User> defaultOAuth2UserService,
-                                   ProfileImageRepository profileImageRepository) {
-        this.userRepository = userRepository;
+    public CustomOAuth2UserService(@Qualifier("defaultOAuth2UserService") OAuth2UserService<OAuth2UserRequest, OAuth2User> defaultOAuth2UserService,
+                                   UserService userService) {
         this.defaultOAuth2UserService = defaultOAuth2UserService;
-        this.profileImageRepository = profileImageRepository;
+        this.userService = userService;
     }
 
     @Override
@@ -38,25 +30,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         Map<String, Object> attributes = oAuth2User.getAttributes();
         GitHubOAuth2UserInfo userInfo = new GitHubOAuth2UserInfo(attributes);
 
-        User user = userRepository.findUserByOauthId(userInfo.getOAuthUserId())
-                .orElseGet(() -> saveTempUser(userInfo));
+        User user = userService.findOrCreateTempUser(userInfo);
 
         return new OAuth2UserPrincipal(user, attributes);
-    }
-
-    @Transactional
-    protected User saveTempUser(GitHubOAuth2UserInfo oAuth2UserInfo) {
-        final User tempUser = User.builder()
-                .oauthId(oAuth2UserInfo.getOAuthUserId())
-                .email(oAuth2UserInfo.getEmail())
-                .role(Role.TEMP_USER)
-                .build();
-        final ProfileImage profileImage = ProfileImage.builder()
-                .user(tempUser)
-                .accessUrl(oAuth2UserInfo.getProfileImageUrl())
-                .build();
-        final User saved = userRepository.save(tempUser);
-        profileImageRepository.save(profileImage);
-        return saved;
     }
 }

--- a/server/src/main/java/com/dialog/server/service/DiscussionService.java
+++ b/server/src/main/java/com/dialog/server/service/DiscussionService.java
@@ -42,8 +42,8 @@ public class DiscussionService {
     private final UserRepository userRepository;
 
     @Transactional
-    public DiscussionCreateResponse createDiscussion(DiscussionCreateRequest request, String authorId) {
-        User author = userRepository.findUserByOauthId(authorId)
+    public DiscussionCreateResponse createDiscussion(DiscussionCreateRequest request, Long userId) {
+        User author = userRepository.findById(userId)
                 .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
         Discussion discussion = request.toDiscussion(author);
         try {

--- a/server/src/main/java/com/dialog/server/service/NotificationService.java
+++ b/server/src/main/java/com/dialog/server/service/NotificationService.java
@@ -25,8 +25,8 @@ public class NotificationService {
         this.fcmService = fcmService;
     }
 
-    public TokenCreationResponse addMessagingToken(String oauthId, String token) {
-        final User user = userRepository.findUserByOauthId(oauthId)
+    public TokenCreationResponse addMessagingToken(Long userId, String token) {
+        final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
         final MessagingToken messagingToken = MessagingToken.builder()
                 .user(user)
@@ -39,16 +39,16 @@ public class NotificationService {
         messagingTokenRepository.deleteById(id);
     }
 
-    public List<MyTokenResponse> getMessagingTokensByUserId(String oauthId) {
-        final User user = userRepository.findUserByOauthId(oauthId)
+    public List<MyTokenResponse> getMessagingTokensByUserId(Long userId) {
+        final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
         return messagingTokenRepository.findMessagingTokensByUser(user).stream()
                 .map(MyTokenResponse::from)
                 .toList();
     }
 
-    public void updateToken(String oauthId, Long tokenId, String newToken) {
-        final User user = userRepository.findUserByOauthId(oauthId)
+    public void updateToken(Long userId, Long tokenId, String newToken) {
+        final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
         final MessagingToken messagingToken = messagingTokenRepository.findById(tokenId)
                 .orElseThrow(() -> new DialogException(ErrorCode.BAD_REQUEST));// TODO: 예외 고치기
@@ -58,8 +58,9 @@ public class NotificationService {
         messagingToken.updateToken(newToken);
     }
 
-    public void sendDiscussionCreatedNotification(String authorOAuthId, String path) {
-        final User author = userRepository.findUserByOauthId(authorOAuthId).orElseThrow();
+    public void sendDiscussionCreatedNotification(Long authorId, String path) {
+        final User author = userRepository.findById(authorId)
+                .orElseThrow(); // TODO
         final List<Long> notificationTargetIds = userRepository.findByEmailNotificationAndIdNot(
                 true, author.getId()
         ).stream()

--- a/server/src/main/java/com/dialog/server/service/UserService.java
+++ b/server/src/main/java/com/dialog/server/service/UserService.java
@@ -23,8 +23,8 @@ public class UserService {
     private final ProfileImageRepository profileImageRepository;
 
     @Transactional(readOnly = true)
-    public UserInfoResponse getUserInfo(String oauthId) {
-        User findUser = userRepository.findUserByOauthId(oauthId)
+    public UserInfoResponse getUserInfo(Long userId) {
+        User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
         return UserInfoResponse.from(findUser);
     }
@@ -50,9 +50,9 @@ public class UserService {
         return saved;
     }
 
-    public NotificationSettingResponse updateNotification(NotificationSettingRequest request, String oauthId) {
+    public NotificationSettingResponse updateNotification(NotificationSettingRequest request, Long userId) {
         boolean notificationEnable = request.isNotificationEnable();
-        User user = userRepository.findUserByOauthId(oauthId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
         user.updateNotificationSetting(notificationEnable);
         User updatedUser = userRepository.save(user);

--- a/server/src/main/java/com/dialog/server/service/UserService.java
+++ b/server/src/main/java/com/dialog/server/service/UserService.java
@@ -1,11 +1,15 @@
 package com.dialog.server.service;
 
+import com.dialog.server.domain.ProfileImage;
+import com.dialog.server.domain.Role;
 import com.dialog.server.domain.User;
 import com.dialog.server.dto.auth.request.NotificationSettingRequest;
 import com.dialog.server.dto.auth.response.NotificationSettingResponse;
 import com.dialog.server.dto.auth.response.UserInfoResponse;
+import com.dialog.server.dto.security.GitHubOAuth2UserInfo;
 import com.dialog.server.exception.DialogException;
 import com.dialog.server.exception.ErrorCode;
+import com.dialog.server.repository.ProfileImageRepository;
 import com.dialog.server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,12 +20,34 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ProfileImageRepository profileImageRepository;
 
     @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(String oauthId) {
         User findUser = userRepository.findUserByOauthId(oauthId)
                 .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
         return UserInfoResponse.from(findUser);
+    }
+
+    @Transactional
+    public User findOrCreateTempUser(GitHubOAuth2UserInfo userInfo) {
+        return userRepository.findUserByOauthId(userInfo.getOAuthUserId())
+                .orElseGet(() -> saveTempUser(userInfo));
+    }
+
+    private User saveTempUser(GitHubOAuth2UserInfo oAuth2UserInfo) {
+        final User tempUser = User.builder()
+                .oauthId(oAuth2UserInfo.getOAuthUserId())
+                .email(oAuth2UserInfo.getEmail())
+                .role(Role.TEMP_USER)
+                .build();
+        final ProfileImage profileImage = ProfileImage.builder()
+                .user(tempUser)
+                .accessUrl(oAuth2UserInfo.getProfileImageUrl())
+                .build();
+        final User saved = userRepository.save(tempUser);
+        profileImageRepository.save(profileImage);
+        return saved;
     }
 
     public NotificationSettingResponse updateNotification(NotificationSettingRequest request, String oauthId) {

--- a/server/src/test/java/com/dialog/server/service/AuthServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/AuthServiceTest.java
@@ -159,11 +159,11 @@ class AuthServiceTest {
     @DisplayName("등록된 사용자의 인증이 성공적으로 이루어진다")
     void authenticateSuccessTest() {
         // when
-        Authentication authentication = authService.authenticate(user.getOauthId());
+        Authentication authentication = authService.authenticate(user.getId());
 
         // then
         assertThat(authentication.isAuthenticated()).isTrue();
-        assertThat(authentication.getPrincipal()).isEqualTo(user.getOauthId());
+        assertThat(authentication.getPrincipal()).isEqualTo(user.getId());
         assertThat(authentication.getCredentials()).isNull();
 
         assertThat(authentication.getAuthorities()).hasSize(1);
@@ -173,7 +173,7 @@ class AuthServiceTest {
     @DisplayName("존재하지 않는 OAuth ID로 인증 시 예외가 발생한다")
     void authenticateWithNonExistingUserTest() {
         // when, then
-        assertThatThrownBy(() -> authService.authenticate(newOAuthId))
+        assertThatThrownBy(() -> authService.authenticate(999L))
                 .isInstanceOf(DialogException.class);
     }
 
@@ -181,7 +181,7 @@ class AuthServiceTest {
     @DisplayName("등록되지 않은 사용자 인증 시 예외가 발생한다")
     void authenticateUnregisteredUserTest() {
         // when, then
-        assertThatThrownBy(() -> authService.authenticate(tempUser.getOauthId()))
+        assertThatThrownBy(() -> authService.authenticate(tempUser.getId()))
                 .isInstanceOf(DialogException.class);
     }
 }

--- a/server/src/test/java/com/dialog/server/service/CustomOAuth2UserServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/CustomOAuth2UserServiceTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -29,7 +29,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles("test")
 @Import({CustomOAuth2UserService.class, JpaConfig.class})
-@DataJpaTest
+@SpringBootTest
 class CustomOAuth2UserServiceTest {
 
     @Autowired

--- a/server/src/test/java/com/dialog/server/service/DiscussionServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/DiscussionServiceTest.java
@@ -11,10 +11,15 @@ import com.dialog.server.domain.User;
 import com.dialog.server.dto.request.DiscussionCreateRequest;
 import com.dialog.server.dto.request.DiscussionCursorPageRequest;
 import com.dialog.server.dto.request.DiscussionUpdateRequest;
-import com.dialog.server.dto.response.*;
+import com.dialog.server.dto.response.DiscussionCreateResponse;
+import com.dialog.server.dto.response.DiscussionCursorPageResponse;
+import com.dialog.server.dto.response.DiscussionDetailResponse;
+import com.dialog.server.dto.response.DiscussionPreviewResponse;
 import com.dialog.server.repository.DiscussionRepository;
 import com.dialog.server.repository.UserRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -22,9 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
 
 @Transactional
 @ActiveProfiles("test")
@@ -109,7 +111,7 @@ class DiscussionServiceTest {
                     "테스트 요약"
             );
 
-            discussionService.createDiscussion(request, user.getOauthId());
+            discussionService.createDiscussion(request, user.getId());
 
             // 생성 시간에 차이를 두기 위해 약간의 지연 추가
             try {
@@ -330,7 +332,7 @@ class DiscussionServiceTest {
                     "테스트 요약"
             );
 
-            discussionService.createDiscussion(request, i % 2 == 0 ? user1.getOauthId() : user2.getOauthId());
+            discussionService.createDiscussion(request, i % 2 == 0 ? user1.getId() : user2.getId());
 
             // 생성 시간에 차이를 두기 위해 약간의 지연 추가
             try {
@@ -418,6 +420,6 @@ class DiscussionServiceTest {
                 6,
                 Category.BACKEND,
                 "test summary");
-        return discussionService.createDiscussion(request.getFirst(), savedUser.getOauthId());
+        return discussionService.createDiscussion(request.getFirst(), savedUser.getId());
     }
 }

--- a/server/src/test/java/com/dialog/server/service/NotificationServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/NotificationServiceTest.java
@@ -72,7 +72,7 @@ class NotificationServiceTest {
 
         // when
         TokenCreationResponse response = notificationService.addMessagingToken(
-                testUser.getOauthId(), fcmToken
+                testUser.getId(), fcmToken
         );
 
         // then
@@ -88,11 +88,11 @@ class NotificationServiceTest {
     @DisplayName("메시징 토큰 추가 - 존재하지 않는 사용자")
     void addMessagingToken_UserNotFound() {
         // given
-        String nonExistentOauthId = "non-existent-oauth-id";
+        Long nonExistId = 999L;
         String fcmToken = "test-fcm-token-123";
 
         // when & then
-        assertThatThrownBy(() -> notificationService.addMessagingToken(nonExistentOauthId, fcmToken))
+        assertThatThrownBy(() -> notificationService.addMessagingToken(nonExistId, fcmToken))
                 .isInstanceOf(DialogException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }
@@ -129,7 +129,7 @@ class NotificationServiceTest {
         messagingTokenRepository.saveAll(List.of(token1, token2));
 
         // when
-        List<MyTokenResponse> tokens = notificationService.getMessagingTokensByUserId(testUser.getOauthId());
+        List<MyTokenResponse> tokens = notificationService.getMessagingTokensByUserId(testUser.getId());
 
         // then
         assertThat(tokens).hasSize(2);
@@ -141,10 +141,10 @@ class NotificationServiceTest {
     @DisplayName("사용자별 메시징 토큰 조회 - 존재하지 않는 사용자")
     void getMessagingTokensByUserId_UserNotFound() {
         // given
-        String nonExistentOauthId = "non-existent-oauth-id";
+        Long nonExistId = 999L;
 
         // when & then
-        assertThatThrownBy(() -> notificationService.getMessagingTokensByUserId(nonExistentOauthId))
+        assertThatThrownBy(() -> notificationService.getMessagingTokensByUserId(nonExistId))
                 .isInstanceOf(DialogException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }
@@ -161,7 +161,7 @@ class NotificationServiceTest {
         String newToken = "new-token";
 
         // when
-        notificationService.updateToken(testUser.getOauthId(), savedToken.getId(), newToken);
+        notificationService.updateToken(testUser.getId(), savedToken.getId(), newToken);
 
         // then
         MessagingToken updatedToken = messagingTokenRepository.findById(savedToken.getId()).orElse(null);
@@ -181,7 +181,7 @@ class NotificationServiceTest {
 
         // when & then
         assertThatThrownBy(() -> notificationService.updateToken(
-                anotherUser.getOauthId(), savedToken.getId(), "new-token"))
+                anotherUser.getId(), savedToken.getId(), "new-token"))
                 .isInstanceOf(DialogException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
     }
@@ -194,7 +194,7 @@ class NotificationServiceTest {
 
         // when & then
         assertThatThrownBy(() -> notificationService.updateToken(
-                testUser.getOauthId(), nonExistentTokenId, "new-token"))
+                testUser.getId(), nonExistentTokenId, "new-token"))
                 .isInstanceOf(DialogException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
     }
@@ -248,7 +248,7 @@ class NotificationServiceTest {
         String path = "/discussion/123";
 
         // when
-        notificationService.sendDiscussionCreatedNotification(author.getOauthId(), path);
+        notificationService.sendDiscussionCreatedNotification(author.getId(), path);
 
         // then
         final String title = "Dialog";
@@ -281,7 +281,7 @@ class NotificationServiceTest {
         userRepository.save(receiver);
 
         // when
-        notificationService.sendDiscussionCreatedNotification(author.getOauthId(), path);
+        notificationService.sendDiscussionCreatedNotification(author.getId(), path);
 
         // then
         verify(fcmService, times(0)).sendNotification(any(), any(), any(), any());

--- a/server/src/test/java/com/dialog/server/service/UserServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/UserServiceTest.java
@@ -31,16 +31,18 @@ public class UserServiceTest {
 
     private UserService userService;
 
+    private User user;
+
     @BeforeEach
     void setUp() {
         userService = new UserService(userRepository, profileImageRepository);
-        userRepository.save(createUser());
+        user = userRepository.save(createUser());
     }
 
     @Test
     void 유저_정보를_생성한다() {
         //given&when
-        UserInfoResponse userInfo = userService.getUserInfo("oauthId1");
+        UserInfoResponse userInfo = userService.getUserInfo(user.getId());
         //then
         assertAll(
                 () -> assertThat(userInfo.nickname()).isEqualTo("minggom"),
@@ -54,8 +56,8 @@ public class UserServiceTest {
         //given
         NotificationSettingRequest request = new NotificationSettingRequest(false);
         //when
-        userService.updateNotification(request, "oauthId1");
-        UserInfoResponse userInfo = userService.getUserInfo("oauthId1");
+        userService.updateNotification(request, user.getId());
+        UserInfoResponse userInfo = userService.getUserInfo(user.getId());
         //then
         Assertions.assertThat(userInfo.isNotificationEnabled()).isFalse();
     }

--- a/server/src/test/java/com/dialog/server/service/UserServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/UserServiceTest.java
@@ -1,10 +1,14 @@
 package com.dialog.server.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.dialog.server.config.JpaConfig;
 import com.dialog.server.domain.Role;
 import com.dialog.server.domain.User;
 import com.dialog.server.dto.auth.request.NotificationSettingRequest;
 import com.dialog.server.dto.auth.response.UserInfoResponse;
+import com.dialog.server.repository.ProfileImageRepository;
 import com.dialog.server.repository.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,9 +18,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 @Import(JpaConfig.class)
 @ActiveProfiles("test")
 @DataJpaTest
@@ -25,11 +26,14 @@ public class UserServiceTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private ProfileImageRepository profileImageRepository;
+
     private UserService userService;
 
     @BeforeEach
     void setUp() {
-        userService = new UserService(userRepository);
+        userService = new UserService(userRepository, profileImageRepository);
         userRepository.save(createUser());
     }
 


### PR DESCRIPTION
### 변경사항
- `@AuthenticatedUserId` ArgumentResolver 구현으로 컨트롤러에서 사용자 ID 추출 로직 중복 제거
- `CustomOAuth2UserService`의 의존성 간소화 및 예외 처리 개선
- 프로필 이미지 로직 구현 및 관련 테스트 추가
- 일관된 예외 처리를 위한 `DialogException` 적용

### 사용법
```java
// Before
@PostMapping
public ResponseEntity<Void> likeDiscussion(@PathVariable Long discussionsId, Principal principal) {
    Long userId = Long.valueOf(principal.getName());
    // ...
}

// After
@PostMapping
public ResponseEntity<Void> likeDiscussion(@PathVariable Long discussionsId, 
                                          @AuthenticatedUserId Long userId) {
    // ...
}
```
