### PR TITLE
feat: 내 토론, 북마크한 토론 모아보기 및 토론 수정 삭제 UI 구현

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import MyPage from './pages/MyPage/MyPage';
 import './App.css';
 import DiscussionCreateFormPage from './pages/discussion/create/DiscussionCreateFormPage';
 import DiscussionDetailPage from './pages/discussion/detail/DiscussionDetailPage';
+import DiscussionEditFormPage from './pages/discussion/edit/DiscussionEditFormPage';
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
               <Route path="/mypage" element={<MyPage />} />
               <Route path="/discussion/new" element={<DiscussionCreateFormPage />} />
               <Route path="/discussion/:id" element={<DiscussionDetailPage />} />
+              <Route path="/discussion/:id/edit" element={<DiscussionEditFormPage />} />
             </Routes>
           </main>
         </div>

--- a/client/src/api/axios.js
+++ b/client/src/api/axios.js
@@ -6,6 +6,7 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 });
 
 export default api;

--- a/client/src/api/discussion.js
+++ b/client/src/api/discussion.js
@@ -47,3 +47,17 @@ export async function participateDiscussion(id) {
   const res = await api.post(`/discussions/${id}/participants`);
   return res.data;
 }
+
+export async function updateDiscussion(id, { title, content, startDateTime, endDateTime, participantCount, location, track, summary}) {
+  const res = await api.patch(`/discussions/${id}`, {
+    title,
+    content,
+    startAt: startDateTime,
+    endAt: endDateTime,
+    place: location,
+    maxParticipantCount: participantCount,
+    category: track,
+    summary
+  });
+  return res.data;
+}

--- a/client/src/api/discussion.js
+++ b/client/src/api/discussion.js
@@ -61,3 +61,8 @@ export async function updateDiscussion(id, { title, content, startDateTime, endD
   });
   return res.data;
 }
+
+export async function deleteDiscussion(id) {
+  const res = await api.delete(`/discussions/${id}`);
+  return res.data;
+}

--- a/client/src/components/TitleInput/TitleInput.jsx
+++ b/client/src/components/TitleInput/TitleInput.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import './TitleInput.css';
 
-const TitleInput = ({title, setTitle}) => {
+const TitleInput = ({title, setTitle, defaultValue}) => {
   const onChange = (e) => {
     setTitle(e.target.value);
   }
   return (
-    <input value={title} onChange={onChange} className='input' type="text" placeholder="제목에 핵심 내용을 요약해보세요." />
+    <input defaultValue={defaultValue} value={title} onChange={onChange} className='input' type="text" placeholder="제목에 핵심 내용을 요약해보세요." />
   );
 };
 

--- a/client/src/hooks/useMe.js
+++ b/client/src/hooks/useMe.js
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from "react";
+import api from "../api/axios";
+
+const useMe = () => {
+  const hasFetched = useRef(false);
+  const [me, setMe] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (hasFetched.current) return;
+    hasFetched.current = true;
+    fetchMe();
+  }, []);
+
+  const fetchMe = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.get('/user/mine');
+      setMe(res.data.data);
+    } catch (e) {
+      setError('유저 정보를 불러오지 못했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { me, loading, error };
+};
+
+export default useMe;

--- a/client/src/pages/discussion/create/DiscussionCreateFormPage.jsx
+++ b/client/src/pages/discussion/create/DiscussionCreateFormPage.jsx
@@ -40,7 +40,7 @@ const DiscussionCreateFormPage = () => {
     
     try {
       const res = await createDiscussion({ title, content, startDateTime, endDateTime, participantCount, location, track, summary: ""});
-      const discussionId = res.data.disccusionId;
+      const discussionId = res.data.discussionId;
       navigate(`/discussion/${discussionId}`);
     } catch (error) {
       alert(error.response.data.message);

--- a/client/src/pages/discussion/detail/DiscussionDetailPage.css
+++ b/client/src/pages/discussion/detail/DiscussionDetailPage.css
@@ -199,6 +199,58 @@
   opacity: 0.8;
 }
 
+.author-actions {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+}
+
+.edit-button,
+.delete-button {
+  flex: 1;
+  padding: 1rem;
+  border: none;
+  border-radius: var(--border-radius);
+  font-size: 1.1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-speed);
+}
+
+.edit-button {
+  background-color: var(--primary-color);
+  color: white;
+}
+
+.edit-button:hover {
+  filter: brightness(0.95);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(var(--primary-color-rgb), 0.15);
+}
+
+.edit-button:active {
+  transform: translateY(0);
+  box-shadow: none;
+  filter: brightness(0.9);
+}
+
+.delete-button {
+  background-color: #dc3545;
+  color: white;
+}
+
+.delete-button:hover {
+  background-color: #c82333;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(220, 53, 69, 0.15);
+}
+
+.delete-button:active {
+  transform: translateY(0);
+  box-shadow: none;
+  background-color: #bd2130;
+}
+
 /* 마크다운 스타일링 */
 .discussion-detail-content h1 {
   font-size: 1.8rem;
@@ -275,8 +327,7 @@
 @media screen and (max-width: 768px) {
   .discussion-detail-container {
     margin: 1rem auto;
-    padding: 0 1rem;
-    max-width: 100%;
+    padding: 0 0.5rem;
   }
 
   .discussion-detail-wrapper {
@@ -285,51 +336,42 @@
 
   .discussion-title-row {
     flex-direction: column;
-    align-items: flex-start;
     gap: 1rem;
   }
 
   .discussion-actions {
-    width: 100%;
-    justify-content: flex-start;
+    align-self: flex-start;
   }
 
   .discussion-meta {
-    display: flex;
     flex-direction: column;
-    padding: 1rem;
-    margin: 1rem;
+    gap: 0.75rem;
   }
 
   .meta-item {
-    width: 100%;
+    justify-content: space-between;
   }
 
   .participants-list {
-    flex-wrap: wrap;
     gap: 0.5rem;
   }
 
   .participant-item {
-    flex: 1;
-    min-width: calc(50% - 0.5rem);
-    justify-content: center;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
   }
 
   .discussion-detail-header {
-    padding: 1.5rem 1rem;
+    padding: 1.5rem 1rem 1rem;
   }
 
   .discussion-track {
-    font-size: 0.85rem;
-    padding: 0.4rem 0.8rem;
-    margin-bottom: 1rem;
+    font-size: 0.8rem;
+    padding: 0.3rem 0.8rem;
   }
 
   .discussion-title-row {
-    gap: 1rem;
     margin-bottom: 1rem;
-    padding-bottom: 1rem;
   }
 
   .discussion-title-row h1 {
@@ -338,39 +380,38 @@
   }
 
   .discussion-actions {
-    display: flex;
     gap: 0.5rem;
   }
 
   .action-button {
-    padding: 0.5rem 0.8rem;
+    padding: 0.5rem;
+    font-size: 0.9rem;
   }
 
   .action-button svg {
-    font-size: 1.1rem;
+    width: 1rem;
+    height: 1rem;
   }
 
   .action-button span {
-    font-size: 0.9rem;
+    font-size: 0.8rem;
   }
 
   .discussion-creator {
-    margin-bottom: 1.5rem;
-    padding: 0.75rem;
-    gap: 0.5rem;
+    margin-bottom: 1rem;
   }
 
   .creator-image {
-    width: 40px;
-    height: 40px;
+    width: 32px;
+    height: 32px;
   }
 
   .creator-name {
-    font-size: 1rem;
+    font-size: 0.9rem;
   }
 
   .creator-created-at {
-    font-size: 0.9rem;
+    font-size: 0.8rem;
   }
 
   .discussion-detail-content {
@@ -378,82 +419,103 @@
   }
 
   .discussion-detail-content h1 {
-    font-size: 1.5rem;
-    margin: 2rem 0 1rem;
+    font-size: 1.3rem;
   }
 
   .discussion-detail-content h2 {
-    font-size: 1.3rem;
-    margin: 1.5rem 0 1rem;
+    font-size: 1.2rem;
   }
 
   .discussion-detail-content h3 {
     font-size: 1.1rem;
-    margin: 1.25rem 0 0.75rem;
   }
 
   .discussion-detail-content p {
     font-size: 0.95rem;
-    line-height: 1.6;
   }
 
   .discussion-detail-content pre {
-    margin: 1rem 0;
-    border-radius: 8px;
+    font-size: 0.85rem;
   }
 
   .discussion-detail-content code {
-    font-size: 0.85em;
+    font-size: 0.85rem;
   }
 
   .discussion-join-section {
-    padding: 1.5rem 1rem;
+    padding: 1rem;
   }
 
   .join-button {
-    padding: 0.875rem;
     font-size: 1rem;
-    border-radius: 8px;
+    padding: 0.9rem;
+  }
+
+  .author-actions {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .edit-button,
+  .delete-button {
+    font-size: 1rem;
+    padding: 0.9rem;
   }
 }
 
 @media screen and (max-width: 480px) {
   .discussion-detail-container {
-    margin: 0;
-    padding: 0;
+    margin: 0.5rem auto;
+    padding: 0 0.25rem;
   }
 
   .discussion-detail-header {
-    padding: 1rem;
+    padding: 1rem 0.75rem 0.75rem;
   }
 
   .discussion-track {
-    font-size: 0.85rem;
+    font-size: 0.75rem;
+    padding: 0.25rem 0.6rem;
   }
 
   .discussion-title-row h1 {
-    font-size: 1.25rem;
+    font-size: 1.3rem;
   }
 
   .discussion-meta {
-    margin: 0.5rem;
+    padding: 1rem;
   }
 
   .participant-item {
-    min-width: 100%;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.8rem;
   }
 
   .discussion-detail-content {
-    padding: 1rem;
+    padding: 1rem 0.75rem;
   }
 
   .discussion-detail-content pre {
-    margin: 1rem -1rem;
-    border-radius: 0;
+    font-size: 0.8rem;
   }
 
   .discussion-join-section {
-    padding: 1rem;
+    padding: 0.75rem;
+  }
+
+  .join-button {
+    font-size: 0.95rem;
+    padding: 0.8rem;
+  }
+
+  .author-actions {
+    gap: 0.5rem;
+  }
+
+  .edit-button,
+  .delete-button {
+    font-size: 0.95rem;
+    padding: 0.8rem;
   }
 }
 

--- a/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
+++ b/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -7,9 +7,10 @@ import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { FaHeart, FaRegHeart, FaBookmark, FaRegBookmark } from 'react-icons/fa';
 import Header from '../../../components/Header/Header';
 import './DiscussionDetailPage.css';
-import { findDiscussionById, participateDiscussion } from '../../../api/discussion';
+import { findDiscussionById, participateDiscussion, deleteDiscussion } from '../../../api/discussion';
 import { likeDiscussion, deleteLikeDiscussion } from '../../../api/like';
 import { scrapDiscussion, deleteScrapDiscussion } from '../../../api/scrap';
+import useMe from '../../../hooks/useMe';
 
 const TRACKS = [
   { id: 'FRONTEND', name: '프론트엔드' },
@@ -17,7 +18,6 @@ const TRACKS = [
   { id: 'ANDROID', name: '안드로이드' },
   { id: 'COMMON', name: '공통' }
 ];
-
 
 const getDiscussionStatus = (startAt, endAt) => {
   const now = new Date();
@@ -34,8 +34,10 @@ const getDiscussionStatus = (startAt, endAt) => {
 };
 
 const DiscussionDetailPage = () => {
+  const navigate = useNavigate();
   const hasFetched = useRef(false);
   const { id } = useParams();
+  const { me } = useMe();
   const [discussion, setDiscussion] = useState(null);
   const [loading, setLoading] = useState(true);
   const [joining, setJoining] = useState(false);
@@ -49,9 +51,7 @@ const DiscussionDetailPage = () => {
     
     const fetchDiscussion = async () => {
       try {
-        // 임시 데이터
         const res = await findDiscussionById(id);
-
         setDiscussion(res.data);
         setLikeCount(res.data.likeCount);
         setIsBookmarked(res.data.isBookmarked);
@@ -70,11 +70,30 @@ const DiscussionDetailPage = () => {
     try {
       await participateDiscussion(discussion.id);
       alert('토론 참여가 완료되었습니다!');
+      // 페이지 새로고침하여 참여자 목록 업데이트
+      window.location.reload();
     } catch (error) {
       console.error('Failed to join discussion:', error);
       alert(error.response.data.message);
     }
     setJoining(false);
+  };
+
+  const handleEdit = () => {
+    navigate(`/discussion/${id}/edit`);
+  };
+
+  const handleDelete = async () => {
+    if (window.confirm('정말로 이 토론을 삭제하시겠습니까?')) {
+      try {
+        await deleteDiscussion(id);
+        alert('토론이 삭제되었습니다.');
+        navigate('/');
+      } catch (error) {
+        console.error('Failed to delete discussion:', error);
+        alert('토론 삭제 중 오류가 발생했습니다.');
+      }
+    }
   };
 
   const handleLike = async () => {
@@ -116,6 +135,7 @@ const DiscussionDetailPage = () => {
   }
 
   const { status, label } = getDiscussionStatus(discussion.startAt, discussion.endAt);
+  const isAuthor = me?.id === discussion.author.id;
 
   const formatDateTime = (dateTimeStr) => {
     const date = new Date(dateTimeStr);
@@ -165,7 +185,7 @@ const DiscussionDetailPage = () => {
             <div className="discussion-meta">
               <div className="meta-item">
                 <span className="meta-label">장소</span>
-                <span className="meta-value">{discussion.location}</span>
+                <span className="meta-value">{discussion.place}</span>
               </div>
               <div className="meta-item">
                 <span className="meta-label">인원</span>
@@ -229,15 +249,32 @@ const DiscussionDetailPage = () => {
           </div>
 
           <div className="discussion-join-section">
-            <button 
-              className="join-button" 
-              onClick={handleJoin}
-              disabled={joining || discussion.participantCount >= discussion.maxParticipants}
-            >
-              {joining ? '참여 중...' : 
-               discussion.participantCount >= discussion.maxParticipants ? '인원 마감' : 
-               '참여하기'}
-            </button>
+            {isAuthor ? (
+              <div className="author-actions">
+                <button 
+                  className="edit-button" 
+                  onClick={handleEdit}
+                >
+                  수정
+                </button>
+                <button 
+                  className="delete-button" 
+                  onClick={handleDelete}
+                >
+                  삭제
+                </button>
+              </div>
+            ) : (
+              <button 
+                className="join-button" 
+                onClick={handleJoin}
+                disabled={joining || discussion.participantCount >= discussion.maxParticipantCount}
+              >
+                {joining ? '참여 중...' : 
+                 discussion.participantCount >= discussion.maxParticipantCount ? '인원 마감' : 
+                 '참여하기'}
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/client/src/pages/discussion/edit/DiscussionEditFormPage.jsx
+++ b/client/src/pages/discussion/edit/DiscussionEditFormPage.jsx
@@ -1,0 +1,201 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import '../create/DiscussionCreateFormPage.css';
+import TitleInput from '../../../components/TitleInput/TitleInput';
+import MarkdownEditorUiw from '../../../components/MarkdownEditor/MarkdownEditorUiw';
+import Header from '../../../components/Header/Header';
+import { findDiscussionById, updateDiscussion } from '../../../api/discussion';
+
+const TRACKS = [
+  { id: 'FRONTEND', name: '프론트엔드' },
+  { id: 'BACKEND', name: '백엔드' },
+  { id: 'ANDROID', name: '안드로이드' },
+  { id: 'COMMON', name: '공통' }
+];
+
+const DiscussionEditFormPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [date, setDate] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+  const [participantCount, setParticipantCount] = useState(2);
+  const [location, setLocation] = useState('');
+  const [track, setTrack] = useState('FRONTEND');
+  const [isLoading, setIsLoading] = useState(true);
+  console.log(title);
+  useEffect(() => {
+    const fetchDiscussion = async () => {
+      try {
+        const response = await findDiscussionById(id);
+        const discussion = response.data;
+        console.log(discussion.title);
+        // Parse dates
+        const startDate = new Date(discussion.startAt);
+        const endDate = new Date(discussion.endAt);
+        
+        setTitle(discussion.title);
+        setContent(discussion.content);
+        setDate(startDate.toISOString().split('T')[0]);
+        setStartTime(startDate.toTimeString().slice(0, 5));
+        setEndTime(endDate.toTimeString().slice(0, 5));
+        setParticipantCount(discussion.maxParticipantCount);
+        setLocation(discussion.place);
+        setTrack(discussion.track);
+        setIsLoading(false);
+      } catch (error) {
+        alert('토론을 불러오는데 실패했습니다.');
+        navigate('/');
+      }
+    };
+
+    fetchDiscussion();
+  }, [id, navigate]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const startDateTime = formatDateTime(date, startTime);
+    const endDateTime = formatDateTime(date, endTime);
+    try {
+      await updateDiscussion(id, { 
+        title, 
+        content, 
+        startDateTime, 
+        endDateTime,
+        participantCount,
+        location,
+        track,
+        summary: ""
+      });
+      navigate(`/discussion/${id}`);
+    } catch (error) {
+      alert(error.response.data.message);
+    }
+  };
+
+  const formatDateTime = (date, time) => {
+    const dt = new Date(`${date}T${time}`);
+    return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')} ${String(dt.getHours()).padStart(2, '0')}:${String(dt.getMinutes()).padStart(2, '0')}`;
+  };
+
+  const handleParticipantCountChange = (e) => {
+    const value = parseInt(e.target.value) || 2;
+    setParticipantCount(Math.max(2, value));
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="discussion-create-page">
+      <Header />
+      <div className="discussion-create-container">
+        <div className="discussion-create-form">
+          <h1>토론 주제 수정</h1>
+          <form onSubmit={handleSubmit}>
+            <div className="form-group">
+              <TitleInput defaultValue={title} value={title} setTitle={setTitle} />
+            </div>
+
+            <div className="form-row">
+              <div className="form-group flex-1">
+                <label htmlFor="track">트랙</label>
+                <select
+                  id="track"
+                  className="form-input"
+                  value={track}
+                  onChange={(e) => setTrack(e.target.value)}
+                >
+                  {TRACKS.map(t => (
+                    <option key={t.id} value={t.id}>
+                      {t.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group flex-1">
+                <label htmlFor="location">토론 장소</label>
+                <input
+                  type="text"
+                  id="location"
+                  className="form-input"
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                  placeholder="예: 굿샷, 나이스샷, 온라인 줌 미팅"
+                />
+              </div>
+              <div className="form-group participant-count">
+                <label htmlFor="participantCount">참여자 수</label>
+                <input
+                  type="number"
+                  id="participantCount"
+                  className="form-input"
+                  value={participantCount}
+                  onChange={handleParticipantCountChange}
+                  min="2"
+                  placeholder="최소 2명"
+                />
+              </div>
+            </div>
+
+            <div className="datetime-container">
+              <div className="date-field">
+                <label htmlFor="date">날짜</label>
+                <input
+                  type="date"
+                  id="date"
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                />
+              </div>
+              <div className="time-inputs">
+                <div className="time-field">
+                  <label htmlFor="startTime">시작 시간</label>
+                  <input
+                    type="time"
+                    id="startTime"
+                    value={startTime}
+                    onChange={(e) => setStartTime(e.target.value)}
+                    step="1800" // 30분 단위
+                  />
+                </div>
+                <div className="time-field">
+                  <label htmlFor="endTime">종료 시간</label>
+                  <input
+                    type="time"
+                    id="endTime"
+                    value={endTime}
+                    onChange={(e) => setEndTime(e.target.value)}
+                    step="1800" // 30분 단위
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="form-group">
+              <MarkdownEditorUiw value={content} onChange={setContent} />
+            </div>
+
+            <div className="discussion-form-actions">
+              <button 
+                type="button" 
+                className="discussion-button discussion-button-cancel"
+                onClick={() => navigate(`/discussion/${id}`)}
+              >
+                취소
+              </button>
+              <button type="submit" className="discussion-button discussion-button-submit">
+                수정
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DiscussionEditFormPage; 

--- a/client/src/pages/discussion/edit/DiscussionEditFormPage.jsx
+++ b/client/src/pages/discussion/edit/DiscussionEditFormPage.jsx
@@ -25,14 +25,12 @@ const DiscussionEditFormPage = () => {
   const [location, setLocation] = useState('');
   const [track, setTrack] = useState('FRONTEND');
   const [isLoading, setIsLoading] = useState(true);
-  console.log(title);
+  
   useEffect(() => {
     const fetchDiscussion = async () => {
       try {
         const response = await findDiscussionById(id);
         const discussion = response.data;
-        console.log(discussion.title);
-        // Parse dates
         const startDate = new Date(discussion.startAt);
         const endDate = new Date(discussion.endAt);
         

--- a/server/src/main/java/com/dialog/server/controller/DiscussionController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionController.java
@@ -77,7 +77,7 @@ public class DiscussionController {
 
     @PatchMapping("/{id}")
     public ResponseEntity<ApiSuccessResponse<Void>> updateDiscussion(@PathVariable Long id,
-                                                                     DiscussionUpdateRequest request) {
+                                                                     @Valid @RequestBody DiscussionUpdateRequest request) {
         discussionService.updateDiscussion(id, request);
         return ResponseEntity.ok().body(new ApiSuccessResponse<>(null));
     }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionController.java
@@ -35,7 +35,8 @@ public class DiscussionController {
     private final NotificationService notificationService;
 
     @PostMapping
-    public ResponseEntity<ApiSuccessResponse<DiscussionCreateResponse>> postDiscussion(@RequestBody @Valid DiscussionCreateRequest request, @AuthenticatedUserId Long userId) {
+    public ResponseEntity<ApiSuccessResponse<DiscussionCreateResponse>> postDiscussion(
+            @RequestBody @Valid DiscussionCreateRequest request, @AuthenticatedUserId Long userId) {
         DiscussionCreateResponse response = discussionService.createDiscussion(request, userId);
         final URI uri = URI.create("/api/discussions/" + response.discussionId());
         notificationService.sendDiscussionCreatedNotification(userId, uri.getRawPath());
@@ -56,7 +57,8 @@ public class DiscussionController {
             @RequestParam int size
     ) {
         DiscussionCursorPageRequest request = new DiscussionCursorPageRequest(cursor, size);
-        DiscussionCursorPageResponse<DiscussionPreviewResponse> pageDiscussions = discussionService.getDiscussionsPage(request);
+        DiscussionCursorPageResponse<DiscussionPreviewResponse> pageDiscussions = discussionService.getDiscussionsPage(
+                request);
         return ResponseEntity.ok().body(new ApiSuccessResponse<>(pageDiscussions));
     }
 
@@ -74,7 +76,8 @@ public class DiscussionController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<ApiSuccessResponse<Void>> updateDiscussion(@PathVariable Long id, DiscussionUpdateRequest request) {
+    public ResponseEntity<ApiSuccessResponse<Void>> updateDiscussion(@PathVariable Long id,
+                                                                     DiscussionUpdateRequest request) {
         discussionService.updateDiscussion(id, request);
         return ResponseEntity.ok().body(new ApiSuccessResponse<>(null));
     }
@@ -83,5 +86,18 @@ public class DiscussionController {
     public ResponseEntity<ApiSuccessResponse<Void>> deleteDiscussion(@PathVariable Long id) {
         discussionService.deleteDiscussion(id);
         return ResponseEntity.ok().body(new ApiSuccessResponse<>(null));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiSuccessResponse<DiscussionCursorPageResponse<DiscussionPreviewResponse>>> getDiscussionsByLoginUser(
+            @RequestParam(required = false) String cursor,
+            @RequestParam int size,
+            @AuthenticatedUserId Long userId
+    ) {
+        DiscussionCursorPageRequest request = new DiscussionCursorPageRequest(cursor, size);
+        DiscussionCursorPageResponse<DiscussionPreviewResponse> discussionCursorPageResponse = discussionService.getDiscussionByAuthorId(
+                request, userId
+        );
+        return ResponseEntity.ok().body(new ApiSuccessResponse<>(discussionCursorPageResponse));
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionController.java
@@ -98,6 +98,6 @@ public class DiscussionController {
         DiscussionCursorPageResponse<DiscussionPreviewResponse> discussionCursorPageResponse = discussionService.getDiscussionByAuthorId(
                 request, userId
         );
-        return ResponseEntity.ok().body(new ApiSuccessResponse<>(discussionCursorPageResponse));
+        return ResponseEntity.ok(new ApiSuccessResponse<>(discussionCursorPageResponse));
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
@@ -1,34 +1,52 @@
 package com.dialog.server.controller;
 
 import com.dialog.server.dto.auth.AuthenticatedUserId;
+import com.dialog.server.dto.request.ScrapCursorPageRequest;
+import com.dialog.server.dto.response.DiscussionPreviewResponse;
+import com.dialog.server.dto.response.ScrapCursorPageResponse;
+import com.dialog.server.exception.ApiSuccessResponse;
 import com.dialog.server.service.ScrapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/discussions/{discussionId}/scraps")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class DiscussionScrapController {
 
     private final ScrapService scrapService;
 
-    @PostMapping
+    @PostMapping("/discussions/{discussionId}/scraps")
     public ResponseEntity<Void> scrap(@PathVariable Long discussionId, @AuthenticatedUserId Long userId) {
         scrapService.create(userId, discussionId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
     }
 
-    @DeleteMapping
+    @DeleteMapping("/discussions/{discussionId}/scraps")
     public ResponseEntity<Void> deleteScrap(@PathVariable Long discussionId, @AuthenticatedUserId Long userId) {
         scrapService.delete(userId, discussionId);
         return ResponseEntity.noContent()
                 .build();
+    }
+
+    @GetMapping("scraps/me")
+    public ResponseEntity<ApiSuccessResponse<ScrapCursorPageResponse<DiscussionPreviewResponse>>> getScraps(
+            @RequestParam Long lastCursorId,
+            @RequestParam(defaultValue = "10") Integer size,
+            @AuthenticatedUserId Long userId) {
+        ScrapCursorPageRequest scrapCursorPageRequest = new ScrapCursorPageRequest(lastCursorId, size);
+        ScrapCursorPageResponse<DiscussionPreviewResponse> scrapedDiscussions = scrapService.getScrapedDiscussions(
+                scrapCursorPageRequest, userId
+        );
+        return ResponseEntity.ok(new ApiSuccessResponse<>(scrapedDiscussions));
     }
 }

--- a/server/src/main/java/com/dialog/server/dto/auth/response/UserInfoResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/auth/response/UserInfoResponse.java
@@ -3,12 +3,14 @@ package com.dialog.server.dto.auth.response;
 import com.dialog.server.domain.User;
 
 public record UserInfoResponse(
+        Long id,
         String nickname,
         String email,
         boolean isNotificationEnabled
 ) {
     public static UserInfoResponse from(User user) {
         return new UserInfoResponse(
+                user.getId(),
                 user.getNickname(),
                 user.getEmail(),
                 user.isEmailNotification()

--- a/server/src/main/java/com/dialog/server/dto/request/DiscussionUpdateRequest.java
+++ b/server/src/main/java/com/dialog/server/dto/request/DiscussionUpdateRequest.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-
 import java.time.LocalDateTime;
 
 public record DiscussionUpdateRequest(
@@ -27,21 +26,20 @@ public record DiscussionUpdateRequest(
         Integer maxParticipantCount,
         @NotNull
         Category category,
-        @NotBlank
         String summary
 ) {
-        public Discussion toUpdateDiscussion() {
-                return Discussion.builder()
-                        .title(title)
-                        .content(content)
-                        .startAt(startAt)
-                        .endAt(endAt)
-                        .place(place)
-                        .category(category)
-                        .viewCount(0)
-                        .participantCount(1)
-                        .maxParticipantCount(maxParticipantCount)
-                        .summary(summary)
-                        .build();
-        }
+    public Discussion toUpdateDiscussion() {
+        return Discussion.builder()
+                .title(title)
+                .content(content)
+                .startAt(startAt)
+                .endAt(endAt)
+                .place(place)
+                .category(category)
+                .viewCount(0)
+                .participantCount(1)
+                .maxParticipantCount(maxParticipantCount)
+                .summary(summary)
+                .build();
+    }
 }

--- a/server/src/main/java/com/dialog/server/dto/request/ScrapCursorPageRequest.java
+++ b/server/src/main/java/com/dialog/server/dto/request/ScrapCursorPageRequest.java
@@ -1,0 +1,7 @@
+package com.dialog.server.dto.request;
+
+public record ScrapCursorPageRequest(
+        Long lastCursorId,
+        int pageSize
+) {
+}

--- a/server/src/main/java/com/dialog/server/dto/response/ScrapCursorPageResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/response/ScrapCursorPageResponse.java
@@ -1,0 +1,11 @@
+package com.dialog.server.dto.response;
+
+import java.util.List;
+
+public record ScrapCursorPageResponse<T>(
+        List<T> content,
+        Long nextCursorId,
+        boolean hasNext,
+        int size
+) {
+}

--- a/server/src/main/java/com/dialog/server/repository/DiscussionRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/DiscussionRepository.java
@@ -1,11 +1,12 @@
 package com.dialog.server.repository;
 
 import com.dialog.server.domain.Discussion;
+import com.dialog.server.domain.User;
 import jakarta.persistence.LockModeType;
-import org.springframework.data.domain.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -16,13 +17,13 @@ import org.springframework.stereotype.Repository;
 public interface DiscussionRepository extends JpaRepository<Discussion, Long>, DiscussionCustomRepository {
 
     @Query("""
-        SELECT d
-        FROM Discussion d
-        WHERE d.createdAt <= :cursor OR (d.createdAt = :cursor AND d.id < :id)
-        ORDER BY d.createdAt DESC , d.id DESC
-        """)
+            SELECT d
+            FROM Discussion d
+            WHERE d.createdAt <= :cursor OR (d.createdAt = :cursor AND d.id < :id)
+            ORDER BY d.createdAt DESC , d.id DESC
+            """)
     List<Discussion> findDiscussionsBeforeDateCursor(
-            @Param("cursor")LocalDateTime cursor,
+            @Param("cursor") LocalDateTime cursor,
             @Param("id") Long id,
             Pageable pageable
     );
@@ -33,6 +34,27 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long>, D
             ORDER BY d.createdAt DESC, d.id DESC
             """)
     List<Discussion> findFirstPageDiscussionsByDate(Pageable pageable);
+
+    @Query("""
+            SELECT d
+            FROM Discussion d
+            WHERE d.author = :author
+            ORDER BY d.createdAt DESC, d.id DESC
+            """)
+    List<Discussion> findFirstPageDiscussionsByAuthorOrderByDate(Pageable pageable, @Param("author") User author);
+
+    @Query("""
+            SELECT d
+            FROM Discussion d
+            WHERE d.author = :author AND (d.createdAt <= :cursor OR (d.createdAt = :cursor AND d.id < :id))
+            ORDER BY d.createdAt DESC , d.id DESC
+            """)
+    List<Discussion> findDiscussionsByAuthorBeforeDateCursor(
+            @Param("cursor") LocalDateTime cursor,
+            @Param("id") Long id,
+            @Param("author") User author,
+            Pageable pageable
+    );
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT d FROM Discussion d WHERE d.id = :id")

--- a/server/src/main/java/com/dialog/server/repository/ScrapRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/ScrapRepository.java
@@ -3,11 +3,35 @@ package com.dialog.server.repository;
 import com.dialog.server.domain.Discussion;
 import com.dialog.server.domain.Scrap;
 import com.dialog.server.domain.User;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     boolean existsByUserAndDiscussion(User user, Discussion discussion);
 
     void deleteByUserAndDiscussion(User user, Discussion discussion);
+
+    @Query("""
+            SELECT s.discussion
+            FROM Scrap s
+            inner join s.discussion
+            WHERE s.user = :user AND s.id <= :lastScrapId
+            ORDER BY s.id DESC
+            """)
+    List<Discussion> findScrapDiscussionByUser(Pageable pageable,
+                                               @Param("user") User user,
+                                               @Param("lastScrapId") Long lastScrapId);
+
+    @Query("""
+            SELECT s.discussion
+            FROM Scrap s
+            inner join s.discussion
+            WHERE s.user = :user
+            ORDER BY s.id DESC
+            """)
+    List<Discussion> findFirstPageScrapDiscussionByUser(Pageable pageable, @Param("user") User user);
 }

--- a/server/src/main/java/com/dialog/server/service/ScrapService.java
+++ b/server/src/main/java/com/dialog/server/service/ScrapService.java
@@ -3,14 +3,20 @@ package com.dialog.server.service;
 import com.dialog.server.domain.Discussion;
 import com.dialog.server.domain.Scrap;
 import com.dialog.server.domain.User;
+import com.dialog.server.dto.request.ScrapCursorPageRequest;
+import com.dialog.server.dto.response.DiscussionPreviewResponse;
+import com.dialog.server.dto.response.ScrapCursorPageResponse;
 import com.dialog.server.exception.DialogException;
 import com.dialog.server.exception.ErrorCode;
 import com.dialog.server.repository.DiscussionRepository;
 import com.dialog.server.repository.ScrapRepository;
 import com.dialog.server.repository.UserRepository;
-import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +50,22 @@ public class ScrapService {
         scrapRepository.deleteByUserAndDiscussion(user, discussion);
     }
 
+    @Transactional(readOnly = true)
+    public ScrapCursorPageResponse<DiscussionPreviewResponse> getScrapedDiscussions(
+            ScrapCursorPageRequest scrapCursorPageRequest, Long userId) {
+        User user = getUserById(userId);
+        List<Discussion> discussions = findScrapDiscussionsByCursor(scrapCursorPageRequest, user);
+        return createCursorResponse(discussions, scrapCursorPageRequest.pageSize());
+    }
+
+    private List<Discussion> findScrapDiscussionsByCursor(ScrapCursorPageRequest scrapCursorPageRequest, User user) {
+        PageRequest pageRequest = PageRequest.of(0, scrapCursorPageRequest.pageSize() + 1);
+        if (scrapCursorPageRequest.lastCursorId() == null) {
+            return scrapRepository.findFirstPageScrapDiscussionByUser(pageRequest, user);
+        }
+        return scrapRepository.findScrapDiscussionByUser(pageRequest, user, scrapCursorPageRequest.lastCursorId());
+    }
+
     private User getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException(userId + "에 해당하는 user를 찾을 수 없습니다."));
@@ -56,5 +78,24 @@ public class ScrapService {
 
     private boolean isScraped(User user, Discussion discussion) {
         return scrapRepository.existsByUserAndDiscussion(user, discussion);
+    }
+
+    private ScrapCursorPageResponse<DiscussionPreviewResponse> createCursorResponse(
+            List<Discussion> discussions, int requestPageSize) {
+        boolean hasNext = discussions.size() > requestPageSize;
+
+        Long nextCursorId = null;
+
+        List<Discussion> pagingDiscussions = new ArrayList<>(discussions);
+        if (!pagingDiscussions.isEmpty() && hasNext) {
+            Discussion cursorDiscussion = pagingDiscussions.getLast();
+            pagingDiscussions = pagingDiscussions.subList(0, requestPageSize);
+            nextCursorId = cursorDiscussion.getId();
+        }
+
+        List<DiscussionPreviewResponse> responses = pagingDiscussions.stream()
+                .map(DiscussionPreviewResponse::from)
+                .toList();
+        return new ScrapCursorPageResponse<>(responses, nextCursorId, hasNext, requestPageSize);
     }
 }

--- a/server/src/test/java/com/dialog/server/service/DiscussionServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/DiscussionServiceTest.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -103,8 +104,8 @@ class DiscussionServiceTest {
             DiscussionCreateRequest request = createDiscussionRequest(
                     "테스트 제목 " + (i + 1),
                     "테스트 내용입니다",
-                    LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15,0)).plusMinutes(15),
-                    LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15,0)).plusMinutes(30),
+                    LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15, 0)).plusMinutes(15),
+                    LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15, 0)).plusMinutes(30),
                     "테스트 장소",
                     5,
                     Category.BACKEND,
@@ -315,6 +316,36 @@ class DiscussionServiceTest {
         );
     }
 
+    @Test
+    void 토론_작성자를_통해서_커서_기반으로_토론을_조회할_수_있다() {
+        //given
+        User user1 = userRepository.save(createUser());
+        User user2 = userRepository.save(createUser());
+        Discussion discussion1 = discussionRepository.save(createDiscussion(user1));
+        Discussion discussion2 = discussionRepository.save(createDiscussion(user1));
+        discussionRepository.save(createDiscussion(user2));
+        Discussion discussion4 = discussionRepository.save(createDiscussion(user1));
+        Discussion discussion5 = discussionRepository.save(createDiscussion(user1));
+
+        //when
+        DiscussionCursorPageResponse<DiscussionPreviewResponse> result1 = discussionService.getDiscussionByAuthorId(
+                new DiscussionCursorPageRequest(null, 2), user1.getId());
+        DiscussionCursorPageResponse<DiscussionPreviewResponse> result2 = discussionService.getDiscussionByAuthorId(
+                new DiscussionCursorPageRequest(result1.nextCursor(), 2), user1.getId());
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result1.content()).hasSize(2);
+            softly.assertThat(result1.hasNext()).isTrue();
+            softly.assertThat(result1.content()).extracting("id")
+                    .containsExactly(discussion5.getId(), discussion4.getId());
+            softly.assertThat(result2.content()).hasSize(2);
+            softly.assertThat(result2.hasNext()).isFalse();
+            softly.assertThat(result2.content()).extracting("id")
+                    .containsExactly(discussion2.getId(), discussion1.getId());
+        });
+    }
+
     private void createDummyDiscussions(int totalCount) {
         User user1 = userRepository.save(createUser());
         User user2 = userRepository.save(createUser2());
@@ -414,12 +445,28 @@ class DiscussionServiceTest {
                 1,
                 "modified title",
                 "test content",
-                LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15,0)).plusMinutes(15),
-                LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15,0)).plusMinutes(30),
+                LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15, 0)).plusMinutes(15),
+                LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15, 0)).plusMinutes(30),
                 "test place",
                 6,
                 Category.BACKEND,
                 "test summary");
         return discussionService.createDiscussion(request.getFirst(), savedUser.getId());
+    }
+
+    private Discussion createDiscussion(User author) {
+        return Discussion.builder()
+                .title("title")
+                .content("content")
+                .author(author)
+                .startAt(LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15, 0)).plusMinutes(15))
+                .endAt(LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15, 0)).plusMinutes(30))
+                .category(Category.BACKEND)
+                .summary("summary")
+                .maxParticipantCount(4)
+                .participantCount(1)
+                .place("place")
+                .viewCount(2)
+                .build();
     }
 }

--- a/server/src/test/java/com/dialog/server/service/DiscussionServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/DiscussionServiceTest.java
@@ -3,6 +3,7 @@ package com.dialog.server.service;
 import static com.dialog.server.dto.request.SearchType.AUTHOR_NICKNAME;
 import static com.dialog.server.dto.request.SearchType.TITLE_OR_CONTENT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.dialog.server.domain.Category;
@@ -22,7 +23,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.IntStream;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -334,7 +334,7 @@ class DiscussionServiceTest {
                 new DiscussionCursorPageRequest(result1.nextCursor(), 2), user1.getId());
 
         //then
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             softly.assertThat(result1.content()).hasSize(2);
             softly.assertThat(result1.hasNext()).isTrue();
             softly.assertThat(result1.content()).extracting("id")

--- a/server/src/test/java/com/dialog/server/service/NotificationServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/NotificationServiceTest.java
@@ -183,7 +183,7 @@ class NotificationServiceTest {
         assertThatThrownBy(() -> notificationService.updateToken(
                 anotherUser.getId(), savedToken.getId(), "new-token"))
                 .isInstanceOf(DialogException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_TOKEN_ACCESS);
     }
 
     @Test
@@ -196,7 +196,7 @@ class NotificationServiceTest {
         assertThatThrownBy(() -> notificationService.updateToken(
                 testUser.getId(), nonExistentTokenId, "new-token"))
                 .isInstanceOf(DialogException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MESSAGING_TOKEN_NOT_FOUND);
     }
 
     @Test

--- a/server/src/test/java/com/dialog/server/service/ScrapServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/ScrapServiceTest.java
@@ -24,13 +24,15 @@ import java.time.LocalTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @Import(JpaConfig.class)
 @ActiveProfiles("test")
-@DataJpaTest
+@SpringBootTest
+@Transactional
 class ScrapServiceTest {
 
     @Autowired


### PR DESCRIPTION
### 변경 사항 
[BE]
- 내 토론 조회 API를 커서 기반으로 구현했습니다.
- 북마크한 토론 조회 API를 커서 기반으로 구현했습니다.

closes #33

[FE]
- 토론 수정 페이지를 구현했습니다.
- 이제 내가 작성한 토론 상세 정보 페이지를 들어가면 참여하기 버튼 대신 수정, 삭제 버튼이 보이게 됩니다. 
- 수정, 삭제 버튼 클릭시 수정은 수정페이지로 삭제는 토론 삭제로 이어집니다.

closes #34