### PR TITLE
Fix: 토론 게시글 관련 버그 해결

### DIFF
--- a/client/src/components/DiscussionCard.jsx
+++ b/client/src/components/DiscussionCard.jsx
@@ -35,18 +35,24 @@ export default function DiscussionCard({
   const end = new Date(endAt);
   let discussionState = '';
   if (now < start) {
-    discussionState = '모집중';
+    if (participants >= maxParticipants) {
+      discussionState = '모집 완료';
+    } else {
+      discussionState = '모집 중';
+    }
+  
   } else if (now >= start && now <= end) {
-    discussionState = '진행중';
+    discussionState = '토론 중';
   } else {
     discussionState = '완료';
   }
 
   // 상태별 색상
   const stateStyle = {
-    모집중: { background: '#ffe066', color: '#333' },
-    진행중: { background: '#42a5f5', color: '#fff' },
-    완료:   { background: '#bdbdbd', color: '#fff' }
+    '모집 중': { background: '#ffe066', color: '#333' },
+    '모집 완료': { background: '#ff7043', color: '#fff' },
+    '토론 중': { background: '#42a5f5', color: '#fff' },
+    '완료':   { background: '#bdbdbd', color: '#fff' }
   };
 
   return (

--- a/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
+++ b/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
@@ -34,11 +34,17 @@ const getDiscussionStatus = (startAt, endAt) => {
 };
 
 const getAuthorProfileImageSrc = (author) => {
-  if (!author || !author.profileImage) return '';
-  if (author.profileImage.customImageUri) {
-    return author.profileImage.customImageUri;
+  // If no author or no profileImage, use default icon from public assets
+  if (!author || !author.profileImage) return '/src/assets/dialog_icon.png';
+  const { basicImageUri, customImageUri } = author.profileImage;
+  if (customImageUri) {
+    return customImageUri;
   }
-  return author.profileImage.basicImageUri;
+  if (basicImageUri) {
+    return basicImageUri;
+  }
+  // If both are null or undefined, return the default icon from public assets
+  return '/src/assets/dialog_icon.png';
 };
 
 const DiscussionDetailPage = () => {

--- a/server/src/main/java/com/dialog/server/dto/response/DiscussionDetailResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/response/DiscussionDetailResponse.java
@@ -4,7 +4,6 @@ import com.dialog.server.domain.Category;
 import com.dialog.server.domain.Discussion;
 import com.dialog.server.domain.DiscussionParticipant;
 import com.dialog.server.domain.ProfileImage;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -56,7 +55,7 @@ public record DiscussionDetailResponse(
         return new AuthorResponse(
                 discussion.getAuthor().getId(),
                 discussion.getAuthor().getNickname(),
-                ProfileImageResponse.from(profileImage)
+                profileImage == null ? null : ProfileImageResponse.from(profileImage)
         );
     }
 

--- a/server/src/main/java/com/dialog/server/service/DiscussionService.java
+++ b/server/src/main/java/com/dialog/server/service/DiscussionService.java
@@ -79,7 +79,7 @@ public class DiscussionService {
         Discussion discussion = discussionRepository.findById(discussionId)
                 .orElseThrow(() -> new DialogException(ErrorCode.NOT_FOUND_DISCUSSION));
         User author = discussion.getAuthor();
-        ProfileImage profileImage = profileImageRepository.findByUser(author).orElseThrow(() -> new DialogException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
+        ProfileImage profileImage = profileImageRepository.findByUser(author).orElse(null);
         List<DiscussionParticipant> discussionParticipants = discussionParticipantRepository.findByDiscussion(
                 discussion
         );

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -1,353 +1,288 @@
 INSERT INTO users (user_id, nickname, phone_number, email_notification, phone_notification, created_at, modified_at, is_deleted)
 VALUES (1, '김개발', '010-1234-5678', true, true, NOW(), NOW(), false),
        (2, '홍길동', '010-9876-5432', true, false, NOW(), NOW(), false),
-       (3, '박코딩', '010-5555-1234', false, true, NOW(), NOW(), false);
+       (3, '박코딩', '010-5555-1234', false, true, NOW(), NOW(), false),
+       (4, '한스', '010-1111-1111', true, true, NOW(), NOW(), false),
+       (5, '다로', '010-1111-1112', true, false, NOW(), NOW(), false),
+       (6, '밍곰', '010-1111-1113', false, true, NOW(), NOW(), false),
+       (7, '히포', '010-1111-1114', true, true, NOW(), NOW(), false),
+       (8, '서프귀여워', '010-1111-1115', true, false, NOW(), NOW(), false),
+       (9, '차니', '010-1111-1116', false, true, NOW(), NOW(), false)
+;
 
+-- 토론 완료 상태 (과거)
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (100, '모바일 UX 설계 전략', '이 주제에 대한 경험과 전략을 토론합니다.',
-        DATE_ADD(NOW(), INTERVAL '1 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '1 3:00' DAY_MINUTE),
-        '구글 미트', 0, 3, 10, 'ANDROID', '모바일 UX 설계 전략에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '1 0:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 5 DAY),
+        DATE_SUB(NOW(), INTERVAL 5 DAY) + INTERVAL 2 HOUR,
+        '구글 미트', 15, 3, 10, 'ANDROID', '모바일 UX 설계 전략에 대한 경험과 의견 공유', 3,
+        DATE_SUB(NOW(), INTERVAL 7 DAY),
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (101, '대규모 트래픽 처리 전략', '각자의 관점을 공유해 주세요.',
-        DATE_ADD(NOW(), INTERVAL '1 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '1 6:00' DAY_MINUTE),
-        '온라인 줌 미팅', 0, 3, 5, 'BACKEND', '대규모 트래픽 처리 전략에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '1 3:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 3 DAY),
+        DATE_SUB(NOW(), INTERVAL 3 DAY) + INTERVAL 3 HOUR,
+        '온라인 줌 미팅', 22, 5, 5, 'BACKEND', '대규모 트래픽 처리 전략에 대한 경험과 의견 공유', 3,
+        DATE_SUB(NOW(), INTERVAL 5 DAY),
         NOW(), NULL);
 
+-- 토론 중 상태 (현재 진행중)
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (102, '모바일 UX 설계 전략', '각자의 관점을 공유해 주세요.',
-        DATE_ADD(NOW(), INTERVAL '2 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '2 3:00' DAY_MINUTE),
-        '온라인 게더타운', 0, 2, 8, 'ANDROID', '모바일 UX 설계 전략에 대한 경험과 의견 공유', 2,
-        DATE_ADD(NOW(), INTERVAL '2 0:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 1 HOUR),
+        DATE_ADD(NOW(), INTERVAL 1 HOUR),
+        '온라인 게더타운', 8, 2, 8, 'ANDROID', '모바일 UX 설계 전략에 대한 경험과 의견 공유', 2,
+        DATE_SUB(NOW(), INTERVAL 2 DAY),
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (103, '실시간 채팅 구현 전략', '각자의 관점을 공유해 주세요.',
-        DATE_ADD(NOW(), INTERVAL '2 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '2 6:00' DAY_MINUTE),
-        '디스코드 채널', 0, 2, 8, 'ANDROID', '실시간 채팅 구현 전략에 대한 경험과 의견 공유', 1,
-        DATE_ADD(NOW(), INTERVAL '2 3:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 30 MINUTE),
+        DATE_ADD(NOW(), INTERVAL 90 MINUTE),
+        '디스코드 채널', 12, 2, 8, 'ANDROID', '실시간 채팅 구현 전략에 대한 경험과 의견 공유', 1,
+        DATE_SUB(NOW(), INTERVAL 1 DAY),
         NOW(), NULL);
 
+-- 모집 완료 상태 (시작 전이지만 정원 마감)
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (104, 'iOS와 Android 비교', '이 주제에 대한 경험과 전략을 토론합니다.',
-        DATE_ADD(NOW(), INTERVAL '3 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '3 3:00' DAY_MINUTE),
-        '카페 모임', 0, 3, 9, 'BACKEND', 'iOS와 Android 비교에 대한 경험과 의견 공유', 1,
-        DATE_ADD(NOW(), INTERVAL '3 0:50' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 2 HOUR),
+        DATE_ADD(NOW(), INTERVAL 4 HOUR),
+        '카페 모임', 5, 9, 9, 'BACKEND', 'iOS와 Android 비교에 대한 경험과 의견 공유', 1,
+        DATE_SUB(NOW(), INTERVAL 3 DAY),
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (105, 'CI/CD 구축 사례', '이 주제에 대한 경험과 전략을 토론합니다.',
-        DATE_ADD(NOW(), INTERVAL '3 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '3 6:00' DAY_MINUTE),
-        '회사 회의실', 0, 2, 5, 'ANDROID', 'CI/CD 구축 사례에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '3 3:50' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 6 HOUR),
+        DATE_ADD(NOW(), INTERVAL 8 HOUR),
+        '회사 회의실', 3, 5, 5, 'ANDROID', 'CI/CD 구축 사례에 대한 경험과 의견 공유', 3,
+        DATE_SUB(NOW(), INTERVAL 4 DAY),
         NOW(), NULL);
 
+-- 모집 중 상태 (미래 시작, 정원 미달)
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (106, 'AI 도구를 활용한 생산성 향상', '실제 프로젝트에서의 사례 중심으로 이야기해봅시다.',
-        DATE_ADD(NOW(), INTERVAL '4 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '4 3:00' DAY_MINUTE),
-        '구글 미트', 0, 2, 10, 'FRONTEND', 'AI 도구를 활용한 생산성 향상에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '4 0:50' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 1 DAY),
+        DATE_ADD(NOW(), INTERVAL 1 DAY) + INTERVAL 2 HOUR,
+        '구글 미트', 2, 2, 10, 'FRONTEND', 'AI 도구를 활용한 생산성 향상에 대한 경험과 의견 공유', 3,
+        DATE_SUB(NOW(), INTERVAL 10 MINUTE),
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (107, 'GraphQL 활용기', '실제 프로젝트에서의 사례 중심으로 이야기해봅시다.',
-        DATE_ADD(NOW(), INTERVAL '4 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '4 6:00' DAY_MINUTE),
-        '온라인 게더타운', 0, 2, 10, 'ANDROID', 'GraphQL 활용기에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '4 3:50' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 2 DAY),
+        DATE_ADD(NOW(), INTERVAL 2 DAY) + INTERVAL 3 HOUR,
+        '온라인 게더타운', 1, 2, 10, 'ANDROID', 'GraphQL 활용기에 대한 경험과 의견 공유', 3,
+        DATE_SUB(NOW(), INTERVAL 30 MINUTE),
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (108, '협업 툴의 선택 기준', '각자의 관점을 공유해 주세요.',
-        DATE_ADD(NOW(), INTERVAL '5 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '5 3:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 3 DAY),
+        DATE_ADD(NOW(), INTERVAL 3 DAY) + INTERVAL 2 HOUR,
         '온라인 줌 미팅', 0, 1, 7, 'BACKEND', '협업 툴의 선택 기준에 대한 경험과 의견 공유', 1,
-        DATE_ADD(NOW(), INTERVAL '5 0:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 5 MINUTE),
         NOW(), NULL);
 
+-- 추가 과거 토론들 (다양한 시점)
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (109, '클린 아키텍처 적용기', '실제 프로젝트에서의 사례 중심으로 이야기해봅시다.',
-        DATE_ADD(NOW(), INTERVAL '5 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '5 6:00' DAY_MINUTE),
-        '온라인 줌 미팅', 0, 2, 6, 'BACKEND', '클린 아키텍처 적용기에 대한 경험과 의견 공유', 2,
-        DATE_ADD(NOW(), INTERVAL '5 3:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 10 DAY),
+        DATE_SUB(NOW(), INTERVAL 10 DAY) + INTERVAL 2 HOUR,
+        '온라인 줌 미팅', 45, 6, 6, 'BACKEND', '클린 아키텍처 적용기에 대한 경험과 의견 공유', 2,
+        DATE_SUB(NOW(), INTERVAL 12 DAY),
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (110, '클린 아키텍처 적용기', '실제 프로젝트에서의 사례 중심으로 이야기해봅시다.',
-        DATE_ADD(NOW(), INTERVAL '6 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '6 3:00' DAY_MINUTE),
-        '디스코드 채널', 0, 1, 7, 'ANDROID', '클린 아키텍처 적용기에 대한 경험과 의견 공유', 2,
-        DATE_ADD(NOW(), INTERVAL '6 0:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 15 DAY),
+        DATE_SUB(NOW(), INTERVAL 15 DAY) + INTERVAL 3 HOUR,
+        '디스코드 채널', 67, 7, 7, 'ANDROID', '클린 아키텍처 적용기에 대한 경험과 의견 공유', 2,
+        DATE_SUB(NOW(), INTERVAL 18 DAY),
         NOW(), NULL);
 
+-- 미래 모집 중 토론들
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (111, 'iOS와 Android 비교', '이 주제에 대한 경험과 전략을 토론합니다.',
-        DATE_ADD(NOW(), INTERVAL '6 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '6 6:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 5 DAY),
+        DATE_ADD(NOW(), INTERVAL 5 DAY) + INTERVAL 2 HOUR,
         '온라인 게더타운', 0, 2, 9, 'BACKEND', 'iOS와 Android 비교에 대한 경험과 의견 공유', 1,
-        DATE_ADD(NOW(), INTERVAL '6 3:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 2 HOUR),
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (112, 'GraphQL 활용기', '개선 경험과 효과를 나눠주세요.',
-        DATE_ADD(NOW(), INTERVAL '7 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '7 3:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 7 DAY),
+        DATE_ADD(NOW(), INTERVAL 7 DAY) + INTERVAL 2 HOUR,
         '온라인 줌 미팅', 0, 1, 9, 'ANDROID', 'GraphQL 활용기에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '7 0:50' DAY_MINUTE),
+        DATE_SUB(NOW(), INTERVAL 1 HOUR),
         NOW(), NULL);
 
+-- 미래 모집 완료 상태
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (113, '대규모 트래픽 처리 전략', '실제 프로젝트에서의 사례 중심으로 이야기해봅시다.',
-        DATE_ADD(NOW(), INTERVAL '7 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '7 6:00' DAY_MINUTE),
-        '온라인 게더타운', 0, 2, 7, 'BACKEND', '대규모 트래픽 처리 전략에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '7 3:50' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 4 DAY),
+        DATE_ADD(NOW(), INTERVAL 4 DAY) + INTERVAL 3 HOUR,
+        '온라인 게더타운', 1, 7, 7, 'BACKEND', '대규모 트래픽 처리 전략에 대한 경험과 의견 공유', 3,
+        DATE_SUB(NOW(), INTERVAL 3 HOUR),
         NOW(), NULL);
 
+-- 최신 게시글들 (방금 등록)
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (114, 'GraphQL 활용기', '실제 프로젝트에서의 사례 중심으로 이야기해봅시다.',
-        DATE_ADD(NOW(), INTERVAL '8 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '8 3:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 8 DAY),
+        DATE_ADD(NOW(), INTERVAL 8 DAY) + INTERVAL 2 HOUR,
         '카페 모임', 0, 3, 7, 'ANDROID', 'GraphQL 활용기에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '8 0:50' DAY_MINUTE),
+        NOW() - INTERVAL 5 MINUTE,
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (115, '클린 아키텍처 적용기', '각자의 관점을 공유해 주세요.',
-        DATE_ADD(NOW(), INTERVAL '8 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '8 6:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 6 DAY),
+        DATE_ADD(NOW(), INTERVAL 6 DAY) + INTERVAL 2 HOUR,
         '카페 모임', 0, 2, 7, 'ANDROID', '클린 아키텍처 적용기에 대한 경험과 의견 공유', 2,
-        DATE_ADD(NOW(), INTERVAL '8 3:50' DAY_MINUTE),
+        NOW() - INTERVAL 2 MINUTE,
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (116, 'iOS와 Android 비교', '각자의 관점을 공유해 주세요.',
-        DATE_ADD(NOW(), INTERVAL '9 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '9 3:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 9 DAY),
+        DATE_ADD(NOW(), INTERVAL 9 DAY) + INTERVAL 2 HOUR,
         '구글 미트', 0, 2, 7, 'COMMON', 'iOS와 Android 비교에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '9 0:50' DAY_MINUTE),
+        NOW() - INTERVAL 1 MINUTE,
         NOW(), NULL);
 
+-- 가장 최신 게시글
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (117, 'GraphQL 활용기', '실제 프로젝트에서의 사례 중심으로 이야기해봅시다.',
-        DATE_ADD(NOW(), INTERVAL '9 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '9 6:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 10 DAY),
+        DATE_ADD(NOW(), INTERVAL 10 DAY) + INTERVAL 3 HOUR,
         '온라인 게더타운', 0, 3, 10, 'FRONTEND', 'GraphQL 활용기에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '9 3:50' DAY_MINUTE),
+        NOW(),
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (118, '클린 아키텍처 적용기', '실제 프로젝트에서의 사례 중심으로 이야기해봅시다.',
-        DATE_ADD(NOW(), INTERVAL '10 1:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '10 3:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 12 DAY),
+        DATE_ADD(NOW(), INTERVAL 12 DAY) + INTERVAL 2 HOUR,
         '카페 모임', 0, 3, 8, 'COMMON', '클린 아키텍처 적용기에 대한 경험과 의견 공유', 1,
-        DATE_ADD(NOW(), INTERVAL '10 0:50' DAY_MINUTE),
+        NOW() + INTERVAL 30 SECOND,
         NOW(), NULL);
 
 INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
                          max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
 VALUES (119, '대규모 트래픽 처리 전략', '개선 경험과 효과를 나눠주세요.',
-        DATE_ADD(NOW(), INTERVAL '10 4:00' DAY_MINUTE),
-        DATE_ADD(NOW(), INTERVAL '10 6:00' DAY_MINUTE),
+        DATE_ADD(NOW(), INTERVAL 11 DAY),
+        DATE_ADD(NOW(), INTERVAL 11 DAY) + INTERVAL 2 HOUR,
         '디스코드 채널', 0, 2, 8, 'FRONTEND', '대규모 트래픽 처리 전략에 대한 경험과 의견 공유', 3,
-        DATE_ADD(NOW(), INTERVAL '10 3:50' DAY_MINUTE),
+        NOW() + INTERVAL 1 MINUTE,
         NOW(), NULL);
 
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (100, 1, NOW(), NOW());
+INSERT INTO discussions (discussion_id, title, content, start_at, end_at, place, view_count, participant_count,
+                         max_participant_count, category, summary, author_id, created_at, modified_at, deleted_at)
+VALUES (120, '마이크로서비스 아키텍처 설계', '실제 도입 경험과 장단점을 공유해봅시다.',
+        DATE_SUB(NOW(), INTERVAL 45 MINUTE),
+        DATE_ADD(NOW(), INTERVAL 75 MINUTE),
+        '온라인 줌 미팅', 18, 4, 8, 'BACKEND', '마이크로서비스 아키텍처 설계에 대한 경험과 의견 공유', 2,
+        DATE_SUB(NOW(), INTERVAL 2 DAY),
+        NOW(), NULL);
 
+-- 참가자 데이터 (기존과 동일)
 INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (100, 2, NOW(), NOW());
+VALUES (100, 1, NOW(), NOW()),
+       (100, 2, NOW(), NOW()),
+       (100, 3, NOW(), NOW()),
+       (101, 1, NOW(), NOW()),
+       (101, 2, NOW(), NOW()),
+       (101, 3, NOW(), NOW()),
+       (102, 1, NOW(), NOW()),
+       (102, 2, NOW(), NOW()),
+       (103, 1, NOW(), NOW()),
+       (103, 2, NOW(), NOW()),
+       (104, 1, NOW(), NOW()),
+       (104, 2, NOW(), NOW()),
+       (104, 3, NOW(), NOW()),
+       (105, 1, NOW(), NOW()),
+       (105, 3, NOW(), NOW()),
+       (106, 2, NOW(), NOW()),
+       (106, 3, NOW(), NOW()),
+       (107, 1, NOW(), NOW()),
+       (107, 3, NOW(), NOW()),
+       (108, 1, NOW(), NOW()),
+       (109, 2, NOW(), NOW()),
+       (109, 3, NOW(), NOW()),
+       (110, 2, NOW(), NOW()),
+       (111, 1, NOW(), NOW()),
+       (111, 3, NOW(), NOW()),
+       (112, 3, NOW(), NOW()),
+       (113, 2, NOW(), NOW()),
+       (113, 3, NOW(), NOW()),
+       (114, 1, NOW(), NOW()),
+       (114, 2, NOW(), NOW()),
+       (114, 3, NOW(), NOW()),
+       (115, 2, NOW(), NOW()),
+       (115, 3, NOW(), NOW()),
+       (116, 1, NOW(), NOW()),
+       (116, 3, NOW(), NOW()),
+       (117, 1, NOW(), NOW()),
+       (117, 2, NOW(), NOW()),
+       (117, 3, NOW(), NOW()),
+       (118, 1, NOW(), NOW()),
+       (118, 2, NOW(), NOW()),
+       (118, 3, NOW(), NOW()),
+       (119, 1, NOW(), NOW()),
+       (119, 2, NOW(), NOW()),
+       (119, 3, NOW(), NOW()),
+       (119, 4, NOW(), NOW()),
+       (119, 5, NOW(), NOW()),
+       (119, 6, NOW(), NOW()),
+       (119, 7, NOW(), NOW()),
+       (119, 8, NOW(), NOW()),
+       (120, 1, NOW(), NOW()),
+       (120, 3, NOW(), NOW()),
+       (120, 4, NOW(), NOW())
+       ;
 
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (100, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (101, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (101, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (101, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (102, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (102, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (103, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (103, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (104, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (104, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (104, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (105, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (105, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (106, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (106, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (107, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (107, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (108, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (109, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (109, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (110, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (111, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (111, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (112, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (113, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (113, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (114, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (114, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (114, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (115, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (115, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (116, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (116, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (117, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (117, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (117, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (118, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (118, 2, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (118, 3, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (119, 1, NOW(), NOW());
-
-INSERT INTO discussion_participants (discussion_id, participant_id, created_at, modified_at)
-VALUES (119, 3, NOW(), NOW());
-
+-- participant_count 업데이트 (기존과 동일)
 UPDATE discussions SET participant_count = 3 WHERE discussion_id = 100;
-
 UPDATE discussions SET participant_count = 3 WHERE discussion_id = 101;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 102;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 103;
-
 UPDATE discussions SET participant_count = 3 WHERE discussion_id = 104;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 105;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 106;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 107;
-
 UPDATE discussions SET participant_count = 1 WHERE discussion_id = 108;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 109;
-
 UPDATE discussions SET participant_count = 1 WHERE discussion_id = 110;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 111;
-
 UPDATE discussions SET participant_count = 1 WHERE discussion_id = 112;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 113;
-
 UPDATE discussions SET participant_count = 3 WHERE discussion_id = 114;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 115;
-
 UPDATE discussions SET participant_count = 2 WHERE discussion_id = 116;
-
 UPDATE discussions SET participant_count = 3 WHERE discussion_id = 117;
-
 UPDATE discussions SET participant_count = 3 WHERE discussion_id = 118;
-
-UPDATE discussions SET participant_count = 2 WHERE discussion_id = 119;
+UPDATE discussions SET participant_count = 8 WHERE discussion_id = 119;
+UPDATE discussions SET participant_count = 4 WHERE discussion_id = 120;


### PR DESCRIPTION
## 수정된 이슈들

### #54 프론트엔드 토론글 상태 이상
- **문제**: 참여자가 최대 참여자보다 크거나 같을 시 모집완료 상태가 되어야하지만 모집 중 상태로 표시됨
- **해결**: 토론글 상태 로직 수정하여 참여자 수 기준으로 올바른 상태 표시되도록 개선

### #47 토론 게시글 단일 조회 시 토론이 존재함에도 "토론을 찾을 수 없다"는 메세지 노출
- **문제**: 백엔드에서 발생한 예외로 "프로필 이미지를 찾을 수 없습니다." 입력도 토론 글 전체가 보이지 않는 문제 발생
- **해결**: 프로필 이미지가 없더라도 기본 이미지를 노출하는 등 다른 방법을 모색할 필요가 있음

## 변경사항

### Frontend
- 토론글 상태 표시 로직 수정
- 참여자 수와 최대 참여자 수 비교 조건 개선
- 모집완료/모집중 상태 올바르게 표시

### Backend  
- 토론 조회 시 프로필 이미지 예외 처리 개선
- 프로필 이미지 없을 경우 기본 이미지 또는 null 처리 로직 추가
- 토론 데이터 조회 실패 방지

## 관련 이슈

Closes #54
Closes #47