### PR TITLE
Fix: 로그인 이후 헤더 초기화 불량 버그 수정

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -13,12 +13,17 @@ import pageStyles from './discussion/search/SearchResultPage.module.css';
 const DEFAULT_PAGE_SIZE = 10;
 
 const Home = () => {
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, checkLoginStatus } = useAuth();
   const { showGuideModal, setShowGuideModal } = useNotification(isLoggedIn);
   const navigate = useNavigate();
   const loaderRef = useRef(null);
   const [searchParams] = useSearchParams();
   const [showFilter, setShowFilter] = useState(true);
+
+  useEffect(() => {
+    checkLoginStatus();
+    // eslint-disable-next-line
+  }, []);
 
   // URL에서 필터 파라미터 추출
   const categories = searchParams.get('categories')?.split(',').filter(Boolean) || [];


### PR DESCRIPTION
## 수정된 이슈

### #46 로그인 이후 헤더 초기화 불량
- **문제**: 로그인 이후 아래와 같은 헤더가 정상이지만, 새로 고침 이전에는 로그인 버튼이 보이는 버그가 존재함
- **해결**: 로그인 상태 변경 시 헤더 컴포넌트가 즉시 업데이트되도록 상태 관리 로직 개선

## 문제 상황
- 사용자가 로그인을 완료한 후에도 헤더에 로그인 버튼이 계속 표시됨
- 페이지를 새로고침해야만 올바른 사용자 정보(My Page, Logout 버튼)가 표시됨
- 로그인 상태와 UI 표시 간의 동기화 문제

## 해결 방안
- 로그인 완료 후 헤더 컴포넌트 상태 즉시 업데이트
- 인증 상태 변경 시 관련 컴포넌트들의 리렌더링 보장
- 로그인/로그아웃 상태 관리 로직 개선

## 변경사항

### Frontend
- 로그인 완료 후 헤더 상태 즉시 업데이트 로직 추가
- 인증 상태 변경 시 헤더 컴포넌트 리렌더링 보장
- 사용자 정보 상태 관리 개선 (My Page, Logout 버튼 표시)

## 관련 이슈

Closes #46