### PR TITLE
Refactor: FE에서 api 주소 중앙에서  관리

### DIFF
--- a/client/src/api/axios.js
+++ b/client/src/api/axios.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:8080/api',
+  baseURL: `${import.meta.env.VITE_API_URL}/api`,
   timeout: 5000,
   headers: {
     'Content-Type': 'application/json',

--- a/client/src/firebase.js
+++ b/client/src/firebase.js
@@ -18,7 +18,7 @@ const messaging = getMessaging(app);
 // FCM 토큰을 서버에 저장
 const saveTokenToServer = async (token) => {
   try {
-    await axios.post('http://localhost:8080/api/fcm-tokens', { token }, { withCredentials: true });
+    await axios.post(`${import.meta.env.VITE_API_URL}/api/fcm-tokens`, { token }, { withCredentials: true });
     // 토큰 저장 성공 시 로컬 스토리지에 저장
     localStorage.setItem('fcmToken', token);
     return token;

--- a/client/src/pages/Login/Login.jsx
+++ b/client/src/pages/Login/Login.jsx
@@ -6,7 +6,7 @@ const Login = () => {
   const handleGithubLogin = () => {
     
     // GitHub OAuth 인증 URL
-    const githubURL = `http://localhost:8080/oauth2/authorization/github`;
+    const githubURL = `${import.meta.env.VITE_API_URL}/oauth2/authorization/github`;
     
     // GitHub 로그인 페이지로 리다이렉트
     window.location.href = githubURL;

--- a/client/src/pages/MyPage/MyPage.jsx
+++ b/client/src/pages/MyPage/MyPage.jsx
@@ -9,7 +9,7 @@ const api = axios.create({
   withCredentials: true
 });
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+const API_BASE_URL = import.meta.env.VITE_API_URL;
 
 const getProfileImageSrc = (profileImage) => {
   if (!profileImage) return '';

--- a/client/src/pages/Signup/Signup.jsx
+++ b/client/src/pages/Signup/Signup.jsx
@@ -29,7 +29,7 @@ const Signup = () => {
 
   const checkExistingUser = async () => {
     try {
-      const response = await axios.get('http://localhost:8080/api/signup/check', {
+      const response = await axios.get(`${import.meta.env.VITE_API_URL}/api/signup/check`, {
         withCredentials: true
       });
 
@@ -80,7 +80,7 @@ const Signup = () => {
 
     setIsLoading(true);
     try {
-      await axios.post('http://localhost:8080/api/signup', formData, {
+      await axios.post(`${import.meta.env.VITE_API_URL}/api/signup`, formData, {
         withCredentials: true
       });
       alert('회원가입이 완료되었습니다.');


### PR DESCRIPTION
## 개요

프론트엔드에서 백엔드 api 주소를 한 곳에서 관리하는 것이 아닌 하드코딩 된 경우가 몇 개 있었음.

## 변경 사항

### Frontend
- .env 파일에 있는 변수값을 사용하는 것으로 변경

### Backend
변경사항 없음

this closes #57 