### PR TITLE
refactor: 토론 조회 카드의 조회수 정보 제거

### DIFF
--- a/client/src/components/DiscussionCard.jsx
+++ b/client/src/components/DiscussionCard.jsx
@@ -110,7 +110,6 @@ export default function DiscussionCard({
       </div>
       <div style={{ display: 'flex', gap: 24, fontSize: 14, color: '#666' }}>
         <span>참여: {participants} / {maxParticipants}명</span>
-        <span>조회수: {views}</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## 기존
- 부정확한 조회수 정보 노출

## 변경사항
- 조회수 정보 제거
<img width="622" height="234" alt="image" src="https://github.com/user-attachments/assets/3813ea8e-e5f3-447b-9860-9ecdf4502491" />

## Description
- 백엔드에서 Entity를 건드리지 않고 프론트엔드에서만 정보 노출을 하지 않는 방향으로 수정

this closes #63 