### PR TITLE
refactor: 좋아요 누른 후 새로고침시 오류 발생 버그 수정

### DIFF
--- a/client/src/api/like.js
+++ b/client/src/api/like.js
@@ -10,3 +10,8 @@ export async function deleteLikeDiscussion(discussionsId) {
   const res = await api.delete(`/discussions/${discussionsId}/likes`);
   return res.data;
 }
+
+export async function getLikeStatus(discussionsId) {
+  const res = await api.get(`/discussions/${discussionsId}/likes/status`);
+  return res.data;
+}

--- a/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
+++ b/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
@@ -8,7 +8,7 @@ import { FaHeart, FaRegHeart, FaBookmark, FaRegBookmark } from 'react-icons/fa';
 import Header from '../../../components/Header/Header';
 import './DiscussionDetailPage.css';
 import { findDiscussionById, participateDiscussion, deleteDiscussion } from '../../../api/discussion';
-import { likeDiscussion, deleteLikeDiscussion } from '../../../api/like';
+import { likeDiscussion, deleteLikeDiscussion, getLikeStatus } from '../../../api/like';
 import { scrapDiscussion, deleteScrapDiscussion } from '../../../api/scrap';
 import useMe from '../../../hooks/useMe';
 
@@ -78,6 +78,25 @@ const DiscussionDetailPage = () => {
 
     fetchDiscussion();
   }, [id]);
+
+  useEffect(() => {
+    if (!me) {
+      setIsLiked(false);
+      return;
+    }
+    
+    const fetchLikeStatus = async () => {
+      try {
+        const likeStatusRes = await getLikeStatus(id);
+        setIsLiked(likeStatusRes.data.isLiked);
+      } catch (error) {
+        console.error('Failed to fetch like status:', error);
+        setIsLiked(false);
+      }
+    };
+
+    fetchLikeStatus();
+  }, [id, me]);
 
   const handleJoin = async () => {
     setJoining(true);

--- a/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionLikeController.java
@@ -1,10 +1,13 @@
 package com.dialog.server.controller;
 
 import com.dialog.server.dto.auth.AuthenticatedUserId;
+import com.dialog.server.dto.response.LikeStatusResponse;
+import com.dialog.server.exception.ApiSuccessResponse;
 import com.dialog.server.service.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,16 +21,27 @@ public class DiscussionLikeController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<Void> likeDiscussion(@PathVariable("discussionsId") Long discussionsId, @AuthenticatedUserId Long userId) {
+    public ResponseEntity<Void> likeDiscussion(@PathVariable("discussionsId") Long discussionsId,
+                                               @AuthenticatedUserId Long userId) {
         likeService.create(userId, discussionsId);
         return ResponseEntity.ok()
                 .build();
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteLikeDiscussion(@PathVariable("discussionsId") Long discussionsId, @AuthenticatedUserId Long userId) {
+    public ResponseEntity<Void> deleteLikeDiscussion(@PathVariable("discussionsId") Long discussionsId,
+                                                     @AuthenticatedUserId Long userId) {
         likeService.delete(userId, discussionsId);
         return ResponseEntity.noContent()
                 .build();
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<ApiSuccessResponse<LikeStatusResponse>> getLikeStatus(
+            @PathVariable("discussionsId") Long discussionsId,
+            @AuthenticatedUserId Long userId
+    ) {
+        boolean liked = likeService.isLiked(userId, discussionsId);
+        return ResponseEntity.ok(new ApiSuccessResponse<>(new LikeStatusResponse(liked)));
     }
 }

--- a/server/src/main/java/com/dialog/server/dto/response/LikeStatusResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/response/LikeStatusResponse.java
@@ -1,0 +1,6 @@
+package com.dialog.server.dto.response;
+
+public record LikeStatusResponse(
+        boolean isLiked
+) {
+}

--- a/server/src/main/java/com/dialog/server/service/LikeService.java
+++ b/server/src/main/java/com/dialog/server/service/LikeService.java
@@ -45,6 +45,14 @@ public class LikeService {
         likeRepository.deleteByUserAndDiscussion(user, discussion);
     }
 
+    @Transactional(readOnly = true)
+    public boolean isLiked(Long userId, Long discussionId) {
+        User user = getUserById(userId);
+        Discussion discussion = getDiscussionById(discussionId);
+
+        return isLiked(user, discussion);
+    }
+
     private User getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException(userId + "에 해당하는 user를 찾을 수 없습니다."));


### PR DESCRIPTION
## 기존
- 기존에 좋아요를 누른 후 새로고침하면 좋아요를 한 상태가 반영이 안되어 좋아요를 한번 더 누르면 좋아요 API가 호출되어 예외 발생

## 변경 사항
- 좋아요를 누르고 새로고침되도 좋아요가 되어있게 해당 게시글에 좋아요를 이미 하고 있는지에 대한 여부 API를 만듦 
- 해당 API를 통해 토론 상세 페이지를 들어가면 좋아요 여부에 따라 좋아요 색을 빨갛게 해줌 

## Description
https://github.com/user-attachments/assets/6d56d766-63f0-494a-be66-61d4fac2a641



this closes #72 