### PR TITLE
refactor: 스크랩 누른 후 새로고침시 오류 발생 버그 수정

### DIFF
--- a/client/src/api/scrap.js
+++ b/client/src/api/scrap.js
@@ -9,3 +9,8 @@ export async function deleteScrapDiscussion(discussionsId) {
   const res = await api.delete(`/discussions/${discussionsId}/scraps`);
   return res.data;
 }
+
+export async function getScrapStatus(discussionId) {
+  const res = await api.get(`/discussions/${discussionId}/scraps/status`);
+  return res.data;
+}

--- a/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
+++ b/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
@@ -8,8 +8,7 @@ import { FaHeart, FaRegHeart, FaBookmark, FaRegBookmark } from 'react-icons/fa';
 import Header from '../../../components/Header/Header';
 import './DiscussionDetailPage.css';
 import { findDiscussionById, participateDiscussion, deleteDiscussion } from '../../../api/discussion';
-import { likeDiscussion, deleteLikeDiscussion } from '../../../api/like';
-import { scrapDiscussion, deleteScrapDiscussion } from '../../../api/scrap';
+import { scrapDiscussion, deleteScrapDiscussion, getScrapStatus } from '../../../api/scrap';
 import useMe from '../../../hooks/useMe';
 
 const TRACKS = [
@@ -78,6 +77,25 @@ const DiscussionDetailPage = () => {
 
     fetchDiscussion();
   }, [id]);
+
+  useEffect(() => {
+    if (!me) {
+      setIsBookmarked(false);
+      return;
+    }
+    
+    const fetchScrapStatus = async () => {
+      try {
+        const scrapStatusRes = await getScrapStatus(id);
+        setIsBookmarked(scrapStatusRes.data.isScraped);
+      } catch (error) {
+        console.error('Failed to fetch scrap status:', error);
+        setIsBookmarked(false);
+      }
+    };
+
+    fetchScrapStatus();
+  }, [id, me]);
 
   const handleJoin = async () => {
     setJoining(true);

--- a/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
@@ -4,6 +4,7 @@ import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.dto.request.ScrapCursorPageRequest;
 import com.dialog.server.dto.response.DiscussionPreviewResponse;
 import com.dialog.server.dto.response.ScrapCursorPageResponse;
+import com.dialog.server.dto.response.ScrapStatusResponse;
 import com.dialog.server.exception.ApiSuccessResponse;
 import com.dialog.server.service.ScrapService;
 import lombok.RequiredArgsConstructor;
@@ -48,5 +49,15 @@ public class DiscussionScrapController {
                 scrapCursorPageRequest, userId
         );
         return ResponseEntity.ok(new ApiSuccessResponse<>(scrapedDiscussions));
+    }
+
+    @GetMapping("/discussions/{discussionId}/scraps/status")
+    public ResponseEntity<ApiSuccessResponse<ScrapStatusResponse>> getScrapStatus(
+            @PathVariable Long discussionId,
+            @AuthenticatedUserId Long userId
+    ) {
+        boolean scraped = scrapService.isScraped(userId, discussionId);
+
+        return ResponseEntity.ok(new ApiSuccessResponse<>(new ScrapStatusResponse(scraped)));
     }
 }

--- a/server/src/main/java/com/dialog/server/dto/response/ScrapStatusResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/response/ScrapStatusResponse.java
@@ -1,4 +1,6 @@
 package com.dialog.server.dto.response;
 
-public class ScrapStatusResponse {
+public record ScrapStatusResponse(
+        boolean isScraped
+) {
 }

--- a/server/src/main/java/com/dialog/server/dto/response/ScrapStatusResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/response/ScrapStatusResponse.java
@@ -1,0 +1,4 @@
+package com.dialog.server.dto.response;
+
+public class ScrapStatusResponse {
+}

--- a/server/src/main/java/com/dialog/server/service/ScrapService.java
+++ b/server/src/main/java/com/dialog/server/service/ScrapService.java
@@ -58,6 +58,13 @@ public class ScrapService {
         return createCursorResponse(discussions, scrapCursorPageRequest.pageSize());
     }
 
+    @Transactional(readOnly = true)
+    public boolean isScraped(Long userId, Long discussionId) {
+        User user = getUserById(userId);
+        Discussion discussion = getDiscussionById(discussionId);
+        return isScraped(user, discussion);
+    }
+
     private List<Discussion> findScrapDiscussionsByCursor(ScrapCursorPageRequest scrapCursorPageRequest, User user) {
         PageRequest pageRequest = PageRequest.of(0, scrapCursorPageRequest.pageSize() + 1);
         if (scrapCursorPageRequest.lastCursorId() == null) {


### PR DESCRIPTION
## 기존
- 기존에 스크랩을 누른 후 새로고침하면 좋아요를 한 상태가 반영이 안되어 스크랩을 한번 더 누르면 스크랩 API가 호출되어 예외 발생

## 변경 사항
- 스크랩을 누르고 새로고침되도 스크랩이 되어있게 해당 게시글에 스크랩을 이미 하고 있는지에 대한 여부 API를 만듦 
- 해당 API를 통해 토론 상세 페이지를 들어가면 스크랩 여부에 따라 스크랩 색을 빨갛게 해줌 

## Description
https://github.com/user-attachments/assets/7f1a8d5c-7b5b-4257-a9a2-9a84e53bd9b6

