### PR TITLE
refactor: 토론 생성시 토론 참여자에 insert 로직 추가

### DIFF
--- a/server/src/main/java/com/dialog/server/dto/request/DiscussionCreateRequest.java
+++ b/server/src/main/java/com/dialog/server/dto/request/DiscussionCreateRequest.java
@@ -6,7 +6,6 @@ import com.dialog.server.domain.User;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-
 import java.time.LocalDateTime;
 
 public record DiscussionCreateRequest(
@@ -36,7 +35,7 @@ public record DiscussionCreateRequest(
                 .place(place)
                 .category(category)
                 .viewCount(0)
-                .participantCount(1)
+                .participantCount(0)
                 .maxParticipantCount(maxParticipantCount)
                 .summary(summary)
                 .author(author)

--- a/server/src/main/java/com/dialog/server/service/DiscussionService.java
+++ b/server/src/main/java/com/dialog/server/service/DiscussionService.java
@@ -52,6 +52,7 @@ public class DiscussionService {
         Discussion discussion = request.toDiscussion(author);
         try {
             Discussion savedDiscussion = discussionRepository.save(discussion);
+            participantDiscussion(author, discussion);
             return DiscussionCreateResponse.from(savedDiscussion);
         } catch (IllegalArgumentException ex) {
             throw new DialogException(ErrorCode.CREATE_DISCUSSION_FAILED);
@@ -108,7 +109,8 @@ public class DiscussionService {
         List<Discussion> discussions;
 
         if (cursor == null || cursor.isEmpty()) {
-            discussions = discussionRepository.findWithFiltersPageable(categories, statuses, PageRequest.of(0, pageSize + 1));
+            discussions = discussionRepository.findWithFiltersPageable(categories, statuses,
+                    PageRequest.of(0, pageSize + 1));
 //            discussions = discussionRepository.findFirstPageDiscussionsByDate(PageRequest.of(0, pageSize + 1));
         } else {
             String[] cursorParts = cursor.split(CURSOR_PART_DELIMITER);
@@ -142,8 +144,12 @@ public class DiscussionService {
         validatePageSize(size);
         List<Discussion> discussions;
         switch (searchType) {
-            case TITLE_OR_CONTENT -> discussions = searchDiscussionByTitleOrContentWithFilters(query, categories, statuses, cursor, size);
-            case AUTHOR_NICKNAME -> discussions = searchDiscussionByAuthorNicknameWithFilters(query, categories, statuses, cursor, size);
+            case TITLE_OR_CONTENT ->
+                    discussions = searchDiscussionByTitleOrContentWithFilters(query, categories, statuses, cursor,
+                            size);
+            case AUTHOR_NICKNAME ->
+                    discussions = searchDiscussionByAuthorNicknameWithFilters(query, categories, statuses, cursor,
+                            size);
             default -> throw new DialogException(ErrorCode.INVALID_SEARCH_TYPE);
         }
         return buildDateCursorResponse(discussions, size);
@@ -276,5 +282,14 @@ public class DiscussionService {
                 .map(DiscussionPreviewResponse::from)
                 .toList();
         return new DiscussionCursorPageResponse<>(responses, nextCursor, hasNext, pageSize);
+    }
+
+    private void participantDiscussion(User author, Discussion discussion) {
+        DiscussionParticipant discussionParticipant = DiscussionParticipant.builder()
+                .participant(author)
+                .discussion(discussion)
+                .build();
+        discussion.participate(LocalDateTime.now(), discussionParticipant);
+        discussionParticipantRepository.save(discussionParticipant);
     }
 }


### PR DESCRIPTION
## 기존
- 게시글 상세 조회시 토론 인원에 토론 생성자가 포함되어있지만 실제 참여자 목록에는 포함되어있지 않음

## 변경 사항
- 토론 생성 로직에서 토론참여자 목록에 토론 생성자를 포함하도록 로직 변경

## Description
<img width="807" height="687" alt="스크린샷 2025-08-31 오후 6 03 31" src="https://github.com/user-attachments/assets/d99d640c-ff6a-43c8-8236-62ce27e876e3" />



this closes #74 