### PR TITLE
refactor: Discussion 등록 시 기본 트랙 지정 및 Discussion 본문 Text Type 변경

### DIFF
--- a/client/src/api/userApi.js
+++ b/client/src/api/userApi.js
@@ -5,6 +5,10 @@ export const userApi = {
   signup: ({email, password, name, nickname}) => {
     return api.post('/users/signup', {email, password, name, nickname});
   },
+  
+  getTrack: () => {
+    return api.get('/mine/track');
+  },
 };
 
 export default userApi;

--- a/client/src/pages/discussion/create/DiscussionCreateFormPage.jsx
+++ b/client/src/pages/discussion/create/DiscussionCreateFormPage.jsx
@@ -5,6 +5,7 @@ import TitleInput from '../../../components/TitleInput/TitleInput';
 import MarkdownEditorUiw from '../../../components/MarkdownEditor/MarkdownEditorUiw';
 import Header from '../../../components/Header/Header';
 import { createDiscussion } from '../../../api/discussion';
+import { userApi } from '../../../api/userApi';
 
 const TRACKS = [
   { id: 'FRONTEND', name: '프론트엔드' },
@@ -75,6 +76,20 @@ const DiscussionCreateFormPage = () => {
     setDate(getDefaultDate());
     setStartTime(getDefaultTime(1)); // 1시간 후
     setEndTime(getDefaultTime(2));   // 2시간 후
+    
+    // 사용자 트랙 조회하여 기본값 설정
+    const fetchUserTrack = async () => {
+      try {
+        const response = await userApi.getTrack();
+        const userTrack = response.data.data.track;
+        setTrack(userTrack);
+      } catch (error) {
+        console.error('Failed to fetch user track:', error);
+        // 에러 시 기본값 유지 (FRONTEND)
+      }
+    };
+    
+    fetchUserTrack();
   }, []);
 
   return (

--- a/server/src/main/java/com/dialog/server/controller/UserController.java
+++ b/server/src/main/java/com/dialog/server/controller/UserController.java
@@ -4,6 +4,7 @@ import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.dto.auth.request.NotificationSettingRequest;
 import com.dialog.server.dto.auth.response.NotificationSettingResponse;
 import com.dialog.server.dto.auth.response.UserInfoResponse;
+import com.dialog.server.dto.response.MyTrackGetTrackResponse;
 import com.dialog.server.dto.response.ProfileImageGetResponse;
 import com.dialog.server.dto.response.ProfileImageUpdateResponse;
 import com.dialog.server.exception.ApiSuccessResponse;
@@ -33,20 +34,29 @@ public class UserController {
     }
 
     @PatchMapping("/mine/notifications")
-    public ResponseEntity<ApiSuccessResponse<NotificationSettingResponse>> patchNotification(@RequestBody @Valid NotificationSettingRequest request, @AuthenticatedUserId Long userId) {
+    public ResponseEntity<ApiSuccessResponse<NotificationSettingResponse>> patchNotification(
+            @RequestBody @Valid NotificationSettingRequest request, @AuthenticatedUserId Long userId) {
         NotificationSettingResponse response = userService.updateNotification(request, userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }
 
     @GetMapping("/mine/profile-image")
-    public ResponseEntity<ApiSuccessResponse<ProfileImageGetResponse>> getProfileImage(@AuthenticatedUserId Long userId) {
+    public ResponseEntity<ApiSuccessResponse<ProfileImageGetResponse>> getProfileImage(
+            @AuthenticatedUserId Long userId) {
         ProfileImageGetResponse response = userService.getProfileImage(userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }
 
     @PatchMapping("/mine/profile-image")
-    public ResponseEntity<ApiSuccessResponse<ProfileImageUpdateResponse>> patchProfileImage(@RequestParam("file") MultipartFile imageFile, @AuthenticatedUserId Long userId) {
+    public ResponseEntity<ApiSuccessResponse<ProfileImageUpdateResponse>> patchProfileImage(
+            @RequestParam("file") MultipartFile imageFile, @AuthenticatedUserId Long userId) {
         ProfileImageUpdateResponse response = userService.updateProfileImage(imageFile, userId);
+        return ResponseEntity.ok(new ApiSuccessResponse<>(response));
+    }
+
+    @GetMapping("/mine/track")
+    public ResponseEntity<ApiSuccessResponse<MyTrackGetTrackResponse>> getTrack(@AuthenticatedUserId Long userId) {
+        MyTrackGetTrackResponse response = userService.getTrack(userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/UserController.java
+++ b/server/src/main/java/com/dialog/server/controller/UserController.java
@@ -49,7 +49,9 @@ public class UserController {
 
     @PatchMapping("/mine/profile-image")
     public ResponseEntity<ApiSuccessResponse<ProfileImageUpdateResponse>> patchProfileImage(
-            @RequestParam("file") MultipartFile imageFile, @AuthenticatedUserId Long userId) {
+            @RequestParam("file") MultipartFile imageFile,
+            @AuthenticatedUserId Long userId
+    ) {
         ProfileImageUpdateResponse response = userService.updateProfileImage(imageFile, userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
     }

--- a/server/src/main/java/com/dialog/server/domain/Discussion.java
+++ b/server/src/main/java/com/dialog/server/domain/Discussion.java
@@ -47,7 +47,7 @@ public class Discussion extends BaseEntity {
     private Long id;
     @Column(nullable = false)
     private String title;
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
     @Column(nullable = false)
     private LocalDateTime startAt;

--- a/server/src/main/java/com/dialog/server/dto/response/MyTrackGetTrackResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/response/MyTrackGetTrackResponse.java
@@ -1,0 +1,12 @@
+package com.dialog.server.dto.response;
+
+import com.dialog.server.domain.Track;
+import com.dialog.server.domain.User;
+
+public record MyTrackGetTrackResponse(Track track) {
+    public static MyTrackGetTrackResponse from(User user) {
+        return new MyTrackGetTrackResponse(
+                user.getTrack()
+        );
+    }
+}

--- a/server/src/main/java/com/dialog/server/service/UserService.java
+++ b/server/src/main/java/com/dialog/server/service/UserService.java
@@ -7,6 +7,7 @@ import com.dialog.server.dto.auth.request.NotificationSettingRequest;
 import com.dialog.server.dto.auth.response.NotificationSettingResponse;
 import com.dialog.server.dto.auth.response.UserInfoResponse;
 import com.dialog.server.dto.response.BasicProfileImageResponse;
+import com.dialog.server.dto.response.MyTrackGetTrackResponse;
 import com.dialog.server.dto.response.ProfileImageGetResponse;
 import com.dialog.server.dto.response.ProfileImageUpdateResponse;
 import com.dialog.server.dto.security.GitHubOAuth2UserInfo;
@@ -80,7 +81,8 @@ public class UserService {
     @Transactional
     public ProfileImageUpdateResponse updateProfileImage(MultipartFile imageFile, Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
-        ProfileImage savedProfileImage = profileImageRepository.findByUser(user).orElseThrow(() -> new DialogException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
+        ProfileImage savedProfileImage = profileImageRepository.findByUser(user)
+                .orElseThrow(() -> new DialogException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
         ProfileImage updateProfile = uploadAndSaveProfileImage(imageFile, savedProfileImage);
         return ProfileImageUpdateResponse.from(updateProfile);
     }
@@ -88,7 +90,8 @@ public class UserService {
     @Transactional(readOnly = true)
     public ProfileImageGetResponse getProfileImage(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
-        ProfileImage profileImage = profileImageRepository.findByUser(user).orElseThrow(() -> new DialogException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
+        ProfileImage profileImage = profileImageRepository.findByUser(user)
+                .orElseThrow(() -> new DialogException(ErrorCode.PROFILE_IMAGE_NOT_FOUND));
         String customImageUri = profileImage.getCustomImageUri();
         String basicImageUri = profileImage.getBasicImageUri();
         return new ProfileImageGetResponse(customImageUri, basicImageUri);
@@ -119,5 +122,10 @@ public class UserService {
         profileImage.updateProfileImage(fileInfo, updatedImageUri);
         profileImageRepository.save(profileImage);
         return profileImage;
+    }
+
+    public MyTrackGetTrackResponse getTrack(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
+        return MyTrackGetTrackResponse.from(user);
     }
 }


### PR DESCRIPTION
1. Discussion 등록 시 기본 트랙 지정 
  - Discussion 등록 화면 진입 시 User 의 Track 조회
  - User 트랙에 따른 기본 트랙 지정
  - 트랙이 없는 경우 FrontEnd 트랙을 지정


2. Discussion 본문 Text Type 변경
  - 기존 Discussion Entity의 Type을 text로 변경