### PR TITLE
refactor: 익명 유저일시 백엔드에서 예외 메시지 구체적으로 정의 및 좋아요, 북마크, 참여하기시 백엔드 예외 코드를 …

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -9,6 +9,7 @@ import NotificationGuideModal from '../components/NotificationGuideModal/Notific
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import DiscussionFilter from '../components/DiscussionFilter';
 import pageStyles from './discussion/search/SearchResultPage.module.css';
+import useMe from '../hooks/useMe';
 
 const DEFAULT_PAGE_SIZE = 10;
 
@@ -125,7 +126,7 @@ const Home = () => {
         )}
       </div>
       {/* 플로팅 액션 버튼 */}
-      <div
+      {isLoggedIn && <div
         style={{
           position: 'fixed',
           bottom: '30px',
@@ -155,7 +156,7 @@ const Home = () => {
         }}
       >
         +
-      </div>
+      </div>}
     </>
   );
 };

--- a/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
+++ b/client/src/pages/discussion/detail/DiscussionDetailPage.jsx
@@ -139,7 +139,7 @@ const DiscussionDetailPage = () => {
         navigate('/');
       } catch (error) {
         console.error('Failed to delete discussion:', error);
-        alert('토론 삭제 중 오류가 발생했습니다.');
+        alert(error.response.data.message);
       }
     }
   };
@@ -156,7 +156,7 @@ const DiscussionDetailPage = () => {
       setIsLiked(!isLiked);
     } catch (error) {
       console.error('Failed to update like:', error);
-      alert('좋아요 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
+      alert(error.response.data.message);
     }
   };
 
@@ -170,7 +170,7 @@ const DiscussionDetailPage = () => {
       setIsBookmarked(!isBookmarked);
     } catch (error) {
       console.error('Failed to update bookmark:', error);
-      alert('스크랩 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
+      alert(error.response.data.message);
     }
   };
 

--- a/server/src/main/java/com/dialog/server/controller/resolver/AuthenticatedUserIdArgumentResolver.java
+++ b/server/src/main/java/com/dialog/server/controller/resolver/AuthenticatedUserIdArgumentResolver.java
@@ -4,6 +4,7 @@ import com.dialog.server.dto.auth.AuthenticatedUserId;
 import com.dialog.server.exception.DialogException;
 import com.dialog.server.exception.ErrorCode;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -30,6 +31,10 @@ public class AuthenticatedUserIdArgumentResolver implements HandlerMethodArgumen
 
         if (authentication == null) {
             throw new DialogException(ErrorCode.AUTHENTICATION_NOT_FOUND);
+        }
+
+        if (authentication instanceof AnonymousAuthenticationToken) {
+            throw new DialogException(ErrorCode.LOGIN_REQUIRED);
         }
 
         try {

--- a/server/src/main/java/com/dialog/server/exception/ErrorCode.java
+++ b/server/src/main/java/com/dialog/server/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     INVALID_SIGNUP("1002", "유효하지 않은 회원가입입니다.", HttpStatus.UNAUTHORIZED),
     AUTHENTICATION_NOT_FOUND("1003", "인증 정보를 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_USER_ID_FORMAT("1004", "유효하지 않은 인증 정보입니다.", HttpStatus.BAD_REQUEST),
+    LOGIN_REQUIRED("1005", "로그인 후 이용할 수 있습니다.", HttpStatus.UNAUTHORIZED),
 
     /**
      * 5XXX - 비즈니스 로직 관련


### PR DESCRIPTION
## 기존
- 로그인 전 접근 불가 경로에 따른 오류 메시지가 명확하지 않았음

## 변경 사항
- 로그인이 안될 경우 백엔드에서 에러 메시지를 구체화 해줌
- 로그인이 안됐을 경우 홈화면에서 +버튼이 안보이게 변경해줌

## Description
**로그인이 안됐을 경우 로그인을 해야하는 api를 호출하는 경우 메시지 형식**
<img width="916" height="734" alt="스크린샷 2025-09-13 오후 5 01 18" src="https://github.com/user-attachments/assets/f60d818e-d047-4780-a9f5-595cb7ef7a68" />

** 로그인이 안된경우 홈 화면에서 +버튼 안보이게 수정**
<img width="1617" height="937" alt="스크린샷 2025-09-13 오후 5 01 51" src="https://github.com/user-attachments/assets/818c13d4-f08f-4291-b3bc-6f782d3390d3" />



this closes #105 