### PR TITLE
feat: 디스커션 조회시 프로필 이미지 추가 및 UI에서 프로필 이미지 보이게 변경

### DIFF
--- a/client/src/components/DiscussionCard.jsx
+++ b/client/src/components/DiscussionCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import dialogIcon from '../assets/dialog_icon.png';
 
 const TRACKS = [
   { id: 'FRONTEND', name: '프론트엔드' },
@@ -7,6 +8,15 @@ const TRACKS = [
   { id: 'ANDROID', name: '안드로이드' },
   { id: 'COMMON', name: '공통' }
 ];
+
+// 프로필 이미지 URL을 가져오는 함수
+const getProfileImageSrc = (profileImage) => {
+  if (!profileImage) return dialogIcon; // 기본 이미지
+  if (profileImage.customImageUri) {
+    return profileImage.customImageUri;
+  }
+  return profileImage.basicImageUri || dialogIcon; // basicImageUri가 없으면 기본 이미지
+};
 
 export default function DiscussionCard({
   id,
@@ -19,7 +29,8 @@ export default function DiscussionCard({
   endAt,
   views,
   title,
-  summary
+  summary,
+  profileImage
 }) {
   const navigate = useNavigate();
   
@@ -98,6 +109,18 @@ export default function DiscussionCard({
       {/* 본문 */}
       <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 8 }}>{title}</div>
       <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
+        <img
+          src={getProfileImageSrc(profileImage)}
+          alt="프로필 이미지"
+          style={{
+            width: '32px',
+            height: '32px',
+            borderRadius: '50%',
+            objectFit: 'cover',
+            marginRight: '12px',
+            border: '2px solid #e0e0e0'
+          }}
+        />
         <div style={{ flex: 1 }}>
           <div style={{ fontWeight: 600, fontSize: 16 }}>{nickname}</div>
           {/* <div style={{ fontSize: 13, color: '#888' }}>{createdAt}</div> */}

--- a/client/src/components/DiscussionList.jsx
+++ b/client/src/components/DiscussionList.jsx
@@ -37,6 +37,7 @@ const DiscussionList = ({
           views={item.viewCount}
           title={item.title}
           summary={item.summary}
+          profileImage={item.profileImage}
         />
       ))}
       {hasMore && (

--- a/server/src/main/java/com/dialog/server/dto/response/DiscussionPreviewResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/response/DiscussionPreviewResponse.java
@@ -2,14 +2,15 @@ package com.dialog.server.dto.response;
 
 import com.dialog.server.domain.Category;
 import com.dialog.server.domain.Discussion;
+import com.dialog.server.domain.ProfileImage;
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.time.LocalDateTime;
 
 public record DiscussionPreviewResponse(
         Long id,
         String title,
         String author,
+        ProfileImageResponse profileImage,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
         LocalDateTime startAt,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
@@ -23,11 +24,12 @@ public record DiscussionPreviewResponse(
         int viewCount
 ) {
 
-    public static DiscussionPreviewResponse from(Discussion discussion) {
+    public static DiscussionPreviewResponse from(Discussion discussion, ProfileImage profileImage) {
         return new DiscussionPreviewResponse(
                 discussion.getId(),
                 discussion.getTitle(),
                 discussion.getAuthor().getNickname(),
+                profileImage == null ? null : ProfileImageResponse.from(profileImage),
                 discussion.getStartAt(),
                 discussion.getEndAt(),
                 discussion.getPlace(),
@@ -38,5 +40,17 @@ public record DiscussionPreviewResponse(
                 discussion.getModifiedAt(),
                 discussion.getViewCount()
         );
+    }
+
+    public record ProfileImageResponse(
+            String basicImageUri,
+            String customImageUri
+    ) {
+        private static ProfileImageResponse from(ProfileImage profileImage) {
+            return new ProfileImageResponse(
+                    profileImage.getBasicImageUri(),
+                    profileImage.getCustomImageUri()
+            );
+        }
     }
 }

--- a/server/src/main/java/com/dialog/server/repository/ProfileImageRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/ProfileImageRepository.java
@@ -2,6 +2,7 @@ package com.dialog.server.repository;
 
 import com.dialog.server.domain.ProfileImage;
 import com.dialog.server.domain.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long
     Optional<ProfileImage> findByUser(User user);
 
     boolean existsByUser(User user);
+
+    List<ProfileImage> findAllByUserIn(List<User> users);
 }

--- a/server/src/test/java/com/dialog/server/service/ScrapServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/ScrapServiceTest.java
@@ -21,7 +21,6 @@ import com.dialog.server.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,13 +43,9 @@ class ScrapServiceTest {
     @Autowired
     private ScrapRepository scrapRepository;
 
+    @Autowired
     private ScrapService scrapService;
-
-    @BeforeEach
-    void setUp() {
-        scrapService = new ScrapService(scrapRepository, userRepository, discussionRepository);
-    }
-
+    
     @Test
     void 사용자는_토론에_북마크를_할_수_있다() {
         //given


### PR DESCRIPTION
## 기존
- 디스커션 조회시 프로필 이미지가 안보였음

## 변경 사항
- 디스커션 조회시 프로필 이미지 추가 및 UI에서 프로필 이미지 보이게 변경

## Description
<img width="1883" height="931" alt="스크린샷 2025-09-13 오후 6 45 11" src="https://github.com/user-attachments/assets/d6853f71-a139-4625-981c-22a398cfa957" />



this closes #107 