### PR TITLE
refactor: 토론 생성시 예외 메시지 구체화 및 bean validation 예외 처리

### DIFF
--- a/server/src/main/java/com/dialog/server/domain/Discussion.java
+++ b/server/src/main/java/com/dialog/server/domain/Discussion.java
@@ -139,40 +139,40 @@ public class Discussion extends BaseEntity {
 
     private void validateTitleLength(String content) {
         if (content.isBlank() || content.length() > MAX_TITLE_LENGTH) {
-            throw new IllegalArgumentException();
+            throw new DialogException(ErrorCode.INVALID_DISCUSSION_TITLE);
         }
     }
 
     private void validateContentLength(String content) {
         if (content.isBlank() || content.length() > MAX_CONTENT_LENGTH) {
-            throw new IllegalArgumentException();
+            throw new DialogException(ErrorCode.INVALID_DISCUSSION_CONTENT);
         }
     }
 
     private void validateSummaryLength(String summary) {
         if (summary.isBlank() || summary.length() > MAX_SUMMARY_LENGTH) {
-            throw new IllegalArgumentException();
+            throw new DialogException(ErrorCode.INVALID_DISCUSSION_SUMMARY);
         }
     }
 
     private void validateTime(LocalDateTime startAt, LocalDateTime endAt) {
         if (startAt.isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException();
+            throw new DialogException(ErrorCode.INVALID_DISCUSSION_TIME);
         }
 
         if (startAt.isAfter(endAt) || endAt.isBefore(startAt)) {
-            throw new IllegalArgumentException();
+            throw new DialogException(ErrorCode.INVALID_DISCUSSION_TIME);
         }
 
         LocalTime startTime = startAt.toLocalTime();
         if (startTime.isBefore(MIN_START_AT) || startTime.isAfter(MAX_START_AT)) {
-            throw new IllegalArgumentException();
+            throw new DialogException(ErrorCode.INVALID_DISCUSSION_START_TIME);
         }
     }
 
     private void validateMaxParticipantCount(int maxParticipantCount) {
         if (maxParticipantCount < MIN_ALLOWED_MAX_PARTICIPANTS || maxParticipantCount > MAX_ALLOWED_MAX_PARTICIPANTS) {
-            throw new IllegalArgumentException();
+            throw new DialogException(ErrorCode.INVALID_DISCUSSION_MAX_PARTICIPANTS);
         }
     }
 

--- a/server/src/main/java/com/dialog/server/exception/ErrorCode.java
+++ b/server/src/main/java/com/dialog/server/exception/ErrorCode.java
@@ -37,6 +37,12 @@ public enum ErrorCode {
     EXIST_USER_EMAIL("5032", "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
     REGISTERED_USER("5033", "이미 회원가입한 회원입니다.", HttpStatus.BAD_REQUEST),
     NOT_REGISTERED_USER("5034", "회원가입하지 않은 회원입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DISCUSSION_TITLE("5035", "제목은 1자 이상 50자 이하로 입력해야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DISCUSSION_CONTENT("5036", "내용은 1자 이상 10,000자 이하로 입력해야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DISCUSSION_SUMMARY("5037", "요약은 1자 이상 300자 이하로 입력해야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DISCUSSION_TIME("5038", "토론 시작/종료 시간이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DISCUSSION_START_TIME("5039", "토론 시작 시간은 08:00~23:00 사이여야 합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DISCUSSION_MAX_PARTICIPANTS("5040", "참여자 수는 1명 이상 10명 이하여야 합니다.", HttpStatus.BAD_REQUEST),
 
     MESSAGING_TOKEN_NOT_FOUND("5041", "메시징 토큰을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     UNAUTHORIZED_TOKEN_ACCESS("5042", "토큰에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/server/src/main/java/com/dialog/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/dialog/server/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.dialog.server.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -11,14 +13,37 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiErrorResponse> handleUnExpectedException(Exception ex) {
-        log.error("예상치 못한 예외가 발생했습니다.",ex);
+        log.error("예상치 못한 예외가 발생했습니다.", ex);
         return ResponseEntity.internalServerError()
                 .body(new ApiErrorResponse("0000", "예기치 못한 에러가 발생하였습니다."));
     }
 
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(
+            MissingServletRequestParameterException exception
+    ) {
+        String defaultErrorMessage = exception.getMessage();
+
+        return ResponseEntity.badRequest()
+                .body(new ApiErrorResponse("0001", defaultErrorMessage));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception
+    ) {
+        String errorMessage = exception.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getField() + "은(는) " + fieldError.getDefaultMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+
+        return ResponseEntity.badRequest()
+                .body(new ApiErrorResponse("0002", errorMessage));
+    }
+
     @ExceptionHandler(DialogException.class)
     public ResponseEntity<ApiErrorResponse> handleUnExpectedException(DialogException ex) {
-        log.warn("경고: ",ex);
+        log.warn("경고: ", ex);
         return ResponseEntity.status(ex.getStatus()).body(ApiErrorResponse.from(ex));
     }
 }


### PR DESCRIPTION
## 기존
- 토론 생성시 예외 메시지가 구체적이지 않음 

## 변경 사항
- 토론 생성시 무엇때문에 실패했는지 백엔드에서 구체화 
- bean validation에서 예외 터질시 500에러 나는거 GlobalExceptionHandler에서 잡아서 처리 

this closes #113 