### PR TITLE
fix: 게시글에서 댓글 집계 시 답글 수까지 합산

### DIFF
--- a/client/src/components/Comment/CommentList.jsx
+++ b/client/src/components/Comment/CommentList.jsx
@@ -81,7 +81,7 @@ const CommentList = ({ discussionId }) => {
   return (
     <div className="comments-section">
       <div className="comments-header">
-        <h3>댓글 {comments.length}개</h3>
+        <h3>댓글 {comments.reduce((total, comment) => total + 1 + ((comment.childComments && comment.childComments.length) || 0), 0)}개</h3>
       </div>
 
       {me && (


### PR DESCRIPTION
# 기존
- 토론 게시글에서 댓글 조회 시 부모 댓글의 수만 합산해서 사용자에게 보여줌

# 변경 사항
- 답글까지 합산