### PR TITLE
fix: 게시글 개수가 페이지 개수 이하인 경우 중복 요청 보내는 코드 수정

### DIFF
--- a/client/src/hooks/useDiscussionList.js
+++ b/client/src/hooks/useDiscussionList.js
@@ -65,7 +65,7 @@ export default function useDiscussionList({ searchParams = null, pageSize = 10 }
 
   // 추가 데이터 로드
   const loadMore = useCallback(async () => {
-    if (!hasMore || isFetchingMore || loading) return;
+    if (!hasMore || isFetchingMore || loading || !cursor) return;
     setIsFetchingMore(true);
     try {
       let result;
@@ -115,5 +115,6 @@ export default function useDiscussionList({ searchParams = null, pageSize = 10 }
     isFetchingMore,
     loadMore,
     reset,
+    hasFetched: hasFetched.current,
   };
 } 

--- a/client/src/hooks/useDiscussionList.js
+++ b/client/src/hooks/useDiscussionList.js
@@ -117,4 +117,4 @@ export default function useDiscussionList({ searchParams = null, pageSize = 10 }
     reset,
     hasFetched: hasFetched.current,
   };
-} 
+}


### PR DESCRIPTION
# 기존
- 페이지 개수 이하를 조회하는 경우 게시글이 두개씩 보임

# 변경 사항
- cusor가 null인 경우, 즉 첫 페이지인 경우에 대한 처리