### PR TITLE
[FIX] 스크랩 커서 페이지네이션 버그 수정

### DIFF
--- a/server/src/main/java/com/dialog/server/repository/ScrapRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/ScrapRepository.java
@@ -16,22 +16,22 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     void deleteByUserAndDiscussion(User user, Discussion discussion);
 
     @Query("""
-            SELECT s.discussion
+            SELECT s
             FROM Scrap s
-            inner join s.discussion
+            join fetch s.discussion
             WHERE s.user = :user AND s.id <= :lastScrapId
             ORDER BY s.id DESC
             """)
-    List<Discussion> findScrapDiscussionByUser(Pageable pageable,
-                                               @Param("user") User user,
-                                               @Param("lastScrapId") Long lastScrapId);
+    List<Scrap> findScrapsByUser(Pageable pageable,
+                                @Param("user") User user,
+                                @Param("lastScrapId") Long lastScrapId);
 
     @Query("""
-            SELECT s.discussion
+            SELECT s
             FROM Scrap s
-            inner join s.discussion
+            join fetch s.discussion
             WHERE s.user = :user
             ORDER BY s.id DESC
             """)
-    List<Discussion> findFirstPageScrapDiscussionByUser(Pageable pageable, @Param("user") User user);
+    List<Scrap> findFirstPageScrapsByUser(Pageable pageable, @Param("user") User user);
 }

--- a/server/src/main/java/com/dialog/server/service/ScrapService.java
+++ b/server/src/main/java/com/dialog/server/service/ScrapService.java
@@ -64,8 +64,8 @@ public class ScrapService {
     public ScrapCursorPageResponse<DiscussionPreviewResponse> getScrapedDiscussions(
             ScrapCursorPageRequest scrapCursorPageRequest, Long userId) {
         User user = getUserById(userId);
-        List<Discussion> discussions = findScrapDiscussionsByCursor(scrapCursorPageRequest, user);
-        return createCursorResponse(discussions, scrapCursorPageRequest.pageSize());
+        List<Scrap> scraps = findScrapsByCursor(scrapCursorPageRequest, user);
+        return createCursorResponse(scraps, scrapCursorPageRequest.pageSize());
     }
 
 
@@ -76,12 +76,12 @@ public class ScrapService {
         return isScraped(user, discussion);
     }
 
-    private List<Discussion> findScrapDiscussionsByCursor(ScrapCursorPageRequest scrapCursorPageRequest, User user) {
+    private List<Scrap> findScrapsByCursor(ScrapCursorPageRequest scrapCursorPageRequest, User user) {
         PageRequest pageRequest = PageRequest.of(0, scrapCursorPageRequest.pageSize() + 1);
         if (scrapCursorPageRequest.lastCursorId() == null) {
-            return scrapRepository.findFirstPageScrapDiscussionByUser(pageRequest, user);
+            return scrapRepository.findFirstPageScrapsByUser(pageRequest, user);
         }
-        return scrapRepository.findScrapDiscussionByUser(pageRequest, user, scrapCursorPageRequest.lastCursorId());
+        return scrapRepository.findScrapsByUser(pageRequest, user, scrapCursorPageRequest.lastCursorId());
     }
 
     private User getUserById(Long userId) {
@@ -99,17 +99,21 @@ public class ScrapService {
     }
 
     private ScrapCursorPageResponse<DiscussionPreviewResponse> createCursorResponse(
-            List<Discussion> discussions, int requestPageSize) {
-        boolean hasNext = discussions.size() > requestPageSize;
+            List<Scrap> scraps, int requestPageSize) {
+        boolean hasNext = scraps.size() > requestPageSize;
 
         Long nextCursorId = null;
 
-        List<Discussion> pagingDiscussions = new ArrayList<>(discussions);
-        if (!pagingDiscussions.isEmpty() && hasNext) {
-            Discussion cursorDiscussion = pagingDiscussions.getLast();
-            pagingDiscussions = pagingDiscussions.subList(0, requestPageSize);
-            nextCursorId = cursorDiscussion.getId();
+        List<Scrap> pagingScraps = new ArrayList<>(scraps);
+        if (!pagingScraps.isEmpty() && hasNext) {
+            Scrap cursorScrap = pagingScraps.getLast();
+            pagingScraps = pagingScraps.subList(0, requestPageSize);
+            nextCursorId = cursorScrap.getId();
         }
+
+        List<Discussion> pagingDiscussions = pagingScraps.stream()
+                .map(Scrap::getDiscussion)
+                .toList();
 
         Map<User, ProfileImage> userProfileImageMap = getAuthorProfileImages(pagingDiscussions);
         Map<Long, Long> commentCountMap = getDiscussionCommentCounts(pagingDiscussions);


### PR DESCRIPTION
## Summary
- 스크랩 목록 커서 페이지네이션에서 `nextCursorId`로 **Discussion ID**가 반환되던 버그 수정
- Repository 쿼리는 `Scrap.id`로 필터링하는데, 커서에 `Discussion.id`가 담겨 ID 불일치로 2페이지 이후 조회가 정상 동작하지 않았음
- Repository 반환 타입을 `List<Discussion>` → `List<Scrap>`으로 변경하여 Scrap ID 정보를 보존하고, 커서에 올바른 Scrap ID를 사용하도록 수정

## 원인 분석
| 항목 | 수정 전 (버그) | 수정 후 |
|---|---|---|
| Repository 반환 타입 | `List<Discussion>` (Scrap ID 유실) | `List<Scrap>` (Scrap ID 보존) |
| `nextCursorId` 값 | `Discussion.getId()` | `Scrap.getId()` |
| JPQL SELECT | `SELECT s.discussion` | `SELECT s` + `join fetch s.discussion` |

## Test plan
- [x] `ScrapServiceTest` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)