### PR TITLE
[DOCS] 스크랩 추가 API 응답 형식 ApiSuccessResponse로 업데이트

### DIFF
--- a/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionScrapController.java
@@ -26,10 +26,10 @@ public class DiscussionScrapController {
     private final ScrapService scrapService;
 
     @PostMapping("/discussions/{discussionId}/scraps")
-    public ResponseEntity<DiscussionDetailResponse> scrap(@PathVariable Long discussionId,
-                                                          @AuthenticatedUserId Long userId) {
+    public ResponseEntity<ApiSuccessResponse<DiscussionDetailResponse>> scrap(@PathVariable Long discussionId,
+                                                                              @AuthenticatedUserId Long userId) {
         DiscussionDetailResponse discussionDetailResponse = scrapService.create(userId, discussionId);
-        return ResponseEntity.ok(discussionDetailResponse);
+        return ResponseEntity.ok(new ApiSuccessResponse<>(discussionDetailResponse));
     }
 
     @DeleteMapping("/discussions/{discussionId}/scraps")

--- a/server/src/main/resources/static/docs/api/discussion-scrap-controller-openapi.yaml
+++ b/server/src/main/resources/static/docs/api/discussion-scrap-controller-openapi.yaml
@@ -38,34 +38,38 @@ paths:
           content:
             application/json:
               schema:
-                $ref: './components/schemas/discussion.yaml#/components/schemas/DiscussionDetailResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: './components/schemas/discussion.yaml#/components/schemas/DiscussionDetailResponse'
               example:
-                id: 1
-                discussionType: "OFFLINE"
-                commonDiscussionInfo:
-                  title: "백엔드 아키텍처 토론"
-                  content: "마이크로서비스 아키텍처에 대해 논의합니다."
-                  summary: null
-                  category: "backend"
-                  createdAt: "2025-11-13T10:00:00"
-                  modifiedAt: "2025-11-14T15:30:00"
-                  likeCount: 15
-                  author:
-                    id: 123
-                    name: "홍길동"
-                    profileImage:
-                      basicImageUri: "https://avatars.githubusercontent.com/u/12345"
-                      customImageUri: null
-                offlineDiscussionInfo:
-                  startAt: "2025-11-20 14:00"
-                  endAt: "2025-11-20 16:00"
-                  place: "강남역 스터디룸"
-                  participantCount: 7
-                  maxParticipantCount: 10
-                  participants:
-                    - id: 456
-                      name: "김철수"
-                onlineDiscussionInfo: null
+                data:
+                  id: 1
+                  discussionType: "OFFLINE"
+                  commonDiscussionInfo:
+                    title: "백엔드 아키텍처 토론"
+                    content: "마이크로서비스 아키텍처에 대해 논의합니다."
+                    summary: null
+                    category: "backend"
+                    createdAt: "2025-11-13T10:00:00"
+                    modifiedAt: "2025-11-14T15:30:00"
+                    likeCount: 15
+                    author:
+                      id: 123
+                      name: "홍길동"
+                      profileImage:
+                        basicImageUri: "https://avatars.githubusercontent.com/u/12345"
+                        customImageUri: null
+                  offlineDiscussionInfo:
+                    startAt: "2025-11-20 14:00"
+                    endAt: "2025-11-20 16:00"
+                    place: "강남역 스터디룸"
+                    participantCount: 7
+                    maxParticipantCount: 10
+                    participants:
+                      - id: 456
+                        name: "김철수"
+                  onlineDiscussionInfo: null
         'error-codes':
           description: "[1005, 5022]"
 


### PR DESCRIPTION
# 📋 연관 이슈

- 연관 이슈 없음

# 🚀 작업 내용

- **`POST /api/discussions/{discussionId}/scraps` 응답 형식을 `ApiSuccessResponse`로 통일**
  - 컨트롤러 반환 타입을 `ResponseEntity<DiscussionDetailResponse>` → `ResponseEntity<ApiSuccessResponse<DiscussionDetailResponse>>`로 변경
  - 응답 본문을 `new ApiSuccessResponse<>(discussionDetailResponse)`로 래핑
  - Swagger YAML 응답 스키마를 `data` 필드로 감싸는 구조로 수정

  **변경 전:**
  ```json
  {
    "id": 1,
    "discussionType": "OFFLINE",
    ...
  }
  ```

  **변경 후:**
  ```json
  {
    "data": {
      "id": 1,
      "discussionType": "OFFLINE",
      ...
    }
  }
  ```

# 💬 리뷰 중점 사항

- `DiscussionScrapController.java:29` — 반환 타입 및 응답 래핑이 다른 엔드포인트(`getScrapStatus`, `getScraps/me`)와 동일한 `ApiSuccessResponse` 패턴을 따르는지 확인
- `discussion-scrap-controller-openapi.yaml:38-75` — 스키마가 `type: object` + `properties.data`로 올바르게 변경되었는지, 예제 값도 `data:` 아래에 위치하는지 확인