### PR TITLE
[FIX] 무한스크롤 다음 페이지 로딩 안 되는 버그 수정

### DIFF
--- a/client/src/hooks/useInfiniteScroll.js
+++ b/client/src/hooks/useInfiniteScroll.js
@@ -15,7 +15,7 @@ export default function useInfiniteScroll({ loadMore, hasMore, loading, isFetchi
     }, { threshold: 1 });
     observer.observe(loaderRef.current);
     return () => observer.disconnect();
-  }, [hasMore]);
+  }, [hasMore, loading]);
 
   return loaderRef;
 }


### PR DESCRIPTION
# 📋 연관 이슈

없음

# 🚀 작업 내용

- `useInfiniteScroll` 훅의 `useEffect` 의존성 배열에 `loading` 추가
  ```js
  // Before
  }, [hasMore]);

  // After
  }, [hasMore, loading]);
  ```
- 마운트 시 `loading=true`로 effect가 실행되지만 sentinel이 아직 DOM에 없어 early return → 이후 `loading=false`로 바뀌어도 `hasMore` 값은 변하지 않아 effect가 재실행되지 않던 문제 해결

# 💬 리뷰 중점 사항

- `src/hooks/useInfiniteScroll.js:18`: `loading` 의존성 추가로 observer 재생성 빈도가 늘어나지만, `loading`은 초기 로딩 1회 + 필터 변경 시에만 toggle되므로 성능 영향 없음
- 호출처 4곳(Home, MyDiscussionPage, ScrapDiscussionPage, SearchResultPage) 모두 이미 `loading`을 전달하고 있어 호환성 문제 없음

## 📝 Additional Description

`usePaginatedList.loadMore()`에 이미 guard 조건(`!hasMore || isFetchingMore || loading || !cursor`)이 있어 observer 재생성으로 인한 중복 fetch는 발생하지 않음