### PR TITLE
[FIX] 회원가입 후 로그인 상태가 반영되지 않는 버그 수정

### DIFF
--- a/client/src/pages/Signup/Signup.jsx
+++ b/client/src/pages/Signup/Signup.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Info } from 'lucide-react';
 import clsx from 'clsx';
 import api from '../../api/axios';
+import { useAuth } from '../../context/AuthContext';
 import Button from '../../components/ui/Button/Button';
 import Tooltip from '../../components/ui/Tooltip/Tooltip';
 import styles from './Signup.module.css';
@@ -11,6 +12,7 @@ const ENABLE_SLACK_GUIDE_PAGE = false;
 
 const Signup = () => {
   const navigate = useNavigate();
+  const { checkLoginStatus } = useAuth();
 
   const [formData, setFormData] = useState({
     track: '',
@@ -46,6 +48,8 @@ const Signup = () => {
       }, {
         withCredentials: true,
       });
+
+      await checkLoginStatus();
 
       if (ENABLE_SLACK_GUIDE_PAGE) {
         navigate('/signup/complete');


### PR DESCRIPTION
# 📋 연관 이슈



# 🚀 작업 내용

- GitHub OAuth 회원가입 완료 후 자동 로그인이 되지 않는 버그 수정
  - 백엔드(`AuthController.signup()`)에서 세션에 인증 정보를 정상 저장하지만, 프론트엔드에서 `navigate('/')` 전에 `checkLoginStatus()`를 호출하지 않아 `AuthContext`의 `isLoggedIn`이 `false`로 유지되는 문제
  - `Signup.jsx`에서 `/api/signup` POST 성공 후 `checkLoginStatus()`를 호출하여 세션 상태를 프론트엔드에 즉시 반영하도록 수정:
    ```jsx
    await api.post('/signup', { ... }, { withCredentials: true });
    await checkLoginStatus(); // 추가
    navigate('/');
    ```

# 💬 리뷰 중점 사항

- `client/src/pages/Signup/Signup.jsx` (49행): `checkLoginStatus()`가 실패할 경우 기존 catch 블록에서 처리되므로 별도 에러 핸들링 불필요한지 확인
- `checkLoginStatus()`는 `AuthContext`에서 `GET /login/check` → `GET /user/mine` 순서로 호출하므로, 회원가입 직후 세션이 확실히 반영된 상태에서 호출되는지 확인

## 📝 Additional Description

`SignupComplete.jsx`에서는 이미 `checkLoginStatus()`를 호출하고 있었으나, `ENABLE_SLACK_GUIDE_PAGE`가 `false`로 설정되어 해당 페이지를 거치지 않고 바로 `/`로 이동하면서 세션 동기화가 누락되었습니다.