### PR TITLE
[FEAT] 댓글 따봉(좋아요) 기능 구현

### DIFF
--- a/client/src/api/commentLike.js
+++ b/client/src/api/commentLike.js
@@ -1,0 +1,11 @@
+import api from "./axios";
+
+export async function likeComment(commentId) {
+  const res = await api.post(`/discussions/comments/${commentId}/likes`);
+  return res.data;
+}
+
+export async function unlikeComment(commentId) {
+  const res = await api.delete(`/discussions/comments/${commentId}/likes`);
+  return res.data;
+}

--- a/client/src/components/Comment/CommentItem.jsx
+++ b/client/src/components/Comment/CommentItem.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Pencil, Trash2, Flag } from 'lucide-react';
+import React, { useState, useCallback, useRef } from 'react';
+import { Pencil, Trash2, Flag, SmilePlus } from 'lucide-react';
 import clsx from 'clsx';
 import MarkdownRender from '../Markdown/MarkdownRender';
 import CommentForm from './CommentForm';
@@ -9,7 +9,9 @@ import ConfirmModal from '../ui/ConfirmModal/ConfirmModal';
 import ReportModal from '../ui/ReportModal/ReportModal';
 import { updateComment, deleteComment } from '../../api/discussion';
 import { reportComment } from '../../api/report';
+import { likeComment, unlikeComment } from '../../api/commentLike';
 import { useAuth } from '../../context/AuthContext';
+import useClickOutside from '../../hooks/useClickOutside';
 import { formatCommentDate } from '../../utils/dateUtils';
 import { getProfileImageSrc } from '../../utils/profileImage';
 import styles from './CommentItem.module.css';
@@ -34,6 +36,11 @@ const CommentItem = ({
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showReportModal, setShowReportModal] = useState(false);
   const [reporting, setReporting] = useState(false);
+  const [isLiked, setIsLiked] = useState(comment.isLiked ?? false);
+  const [likeCount, setLikeCount] = useState(comment.likeCount ?? 0);
+  const [showPicker, setShowPicker] = useState(false);
+  const pickerRef = useRef(null);
+  useClickOutside(pickerRef, () => setShowPicker(false), showPicker);
 
   const isAuthor = me && me.id === comment.author.authorId;
   const hasReplies = comment.childComments?.length > 0;
@@ -88,6 +95,25 @@ const CommentItem = ({
     ];
   };
 
+  const handleLike = useCallback(async () => {
+    if (!me) return;
+    const prevLiked = isLiked;
+    const prevCount = likeCount;
+    setIsLiked(!prevLiked);
+    setLikeCount(prev => prevLiked ? Math.max(0, prev - 1) : prev + 1);
+    try {
+      if (prevLiked) {
+        await unlikeComment(comment.discussionCommentId);
+      } else {
+        await likeComment(comment.discussionCommentId);
+      }
+    } catch (error) {
+      setIsLiked(prevLiked);
+      setLikeCount(prevCount);
+      console.error('Failed to update comment like:', error);
+    }
+  }, [me, isLiked, likeCount, comment.discussionCommentId]);
+
   const handleSaveReply = async (content) => {
     await onReply(content, comment.discussionCommentId);
     setIsReplying(false);
@@ -133,15 +159,50 @@ const CommentItem = ({
           )}
         </div>
 
-        {!isEditing && depth === 0 && me && (
+        {!isEditing && (
           <div className={styles.footer}>
-            <button
-              className={styles.replyBtn}
-              onClick={() => setIsReplying(true)}
-              disabled={isReplying}
-            >
-              답글쓰기
-            </button>
+            {likeCount > 0 && (
+              <button
+                className={clsx(styles.likeBtn, isLiked && styles.likeBtnActive)}
+                onClick={handleLike}
+                disabled={!me}
+                title={!me ? '로그인 후 이용할 수 있습니다' : undefined}
+                aria-label={isLiked ? '따봉 취소' : '따봉'}
+              >
+                👍 <span className={styles.likeCount}>{likeCount}</span>
+              </button>
+            )}
+            {me && (
+              <div className={styles.pickerWrap} ref={pickerRef}>
+                <button
+                  className={styles.pickerTrigger}
+                  onClick={() => setShowPicker(prev => !prev)}
+                  aria-label="이모티콘 추가"
+                >
+                  <SmilePlus size={14} />
+                </button>
+                {showPicker && (
+                  <div className={styles.pickerPopover}>
+                    <button
+                      className={clsx(styles.emojiOption, isLiked && styles.emojiOptionActive)}
+                      onClick={() => { handleLike(); setShowPicker(false); }}
+                      aria-label="따봉"
+                    >
+                      👍
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+            {depth === 0 && me && (
+              <button
+                className={styles.replyBtn}
+                onClick={() => setIsReplying(true)}
+                disabled={isReplying}
+              >
+                답글쓰기
+              </button>
+            )}
           </div>
         )}
 

--- a/client/src/components/Comment/CommentItem.module.css
+++ b/client/src/components/Comment/CommentItem.module.css
@@ -62,7 +62,120 @@
 }
 
 .footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-top: 8px;
+}
+
+.likeBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-text-tertiary);
+  font-size: 12px;
+  font-family: var(--font-family-default);
+  cursor: pointer;
+  line-height: 1.6;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.likeBtn:hover:not(:disabled) {
+  background: var(--color-bg-card-hover);
+  border-color: var(--color-border-strong);
+  color: var(--color-text-secondary);
+}
+
+.likeBtn:disabled {
+  cursor: default;
+}
+
+.likeBtnActive {
+  background: var(--color-accent-orange-light);
+  border-color: var(--color-accent-orange);
+  color: var(--color-accent-orange-dark);
+}
+
+.likeBtnActive:hover:not(:disabled) {
+  background: var(--color-accent-orange-light);
+  border-color: var(--color-accent-orange-dark);
+}
+
+.likeCount {
+  font-weight: 600;
+}
+
+.pickerWrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.pickerTrigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.pickerTrigger:hover {
+  background: var(--color-bg-card-hover);
+  border-color: var(--color-border-default);
+  color: var(--color-text-tertiary);
+}
+
+.pickerPopover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: 200;
+  display: flex;
+  gap: 4px;
+  padding: 6px 8px;
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+.emojiOption {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  font-size: 16px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.1s ease, border-color 0.1s ease;
+  line-height: 1;
+}
+
+.emojiOption:hover {
+  background: var(--color-bg-card-hover);
+  border-color: var(--color-border-default);
+}
+
+.emojiOptionActive {
+  background: var(--color-accent-orange-light);
+  border-color: var(--color-accent-orange);
+}
+
+.emojiOptionActive:hover {
+  background: var(--color-accent-orange-light);
+  border-color: var(--color-accent-orange-dark);
 }
 
 .replyBtn {
@@ -113,6 +226,7 @@
     font-size: 11px;
   }
 
+  .likeBtn,
   .replyBtn {
     font-size: 11px;
   }

--- a/server/src/main/java/com/dialog/server/controller/DiscussionCommentController.java
+++ b/server/src/main/java/com/dialog/server/controller/DiscussionCommentController.java
@@ -6,6 +6,7 @@ import com.dialog.server.dto.comment.request.DiscussionCommentUpdateRequest;
 import com.dialog.server.dto.comment.response.DiscussionCommentCreateResponse;
 import com.dialog.server.dto.comment.response.DiscussionCommentListResponse;
 import com.dialog.server.exception.ApiSuccessResponse;
+import com.dialog.server.service.CommentLikeService;
 import com.dialog.server.service.DiscussionCommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DiscussionCommentController {
 
     private final DiscussionCommentService discussionCommentService;
+    private final CommentLikeService commentLikeService;
 
     @PostMapping("/comments")
     public ResponseEntity<ApiSuccessResponse<DiscussionCommentCreateResponse>> createComment(
@@ -56,9 +58,28 @@ public class DiscussionCommentController {
 
     @GetMapping("/{discussionId}/comments")
     public ResponseEntity<ApiSuccessResponse<DiscussionCommentListResponse>> getComments(
-            @PathVariable Long discussionId
+            @PathVariable Long discussionId,
+            @AuthenticatedUserId(required = false) Long userId
     ) {
-        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(discussionId);
+        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(discussionId, userId);
         return ResponseEntity.ok(new ApiSuccessResponse<>(response));
+    }
+
+    @PostMapping("/comments/{commentId}/likes")
+    public ResponseEntity<ApiSuccessResponse<Void>> likeComment(
+            @PathVariable Long commentId,
+            @AuthenticatedUserId Long userId) {
+
+        commentLikeService.create(userId, commentId);
+        return ResponseEntity.ok(new ApiSuccessResponse<>(null));
+    }
+
+    @DeleteMapping("/comments/{commentId}/likes")
+    public ResponseEntity<ApiSuccessResponse<Void>> unlikeComment(
+            @PathVariable Long commentId,
+            @AuthenticatedUserId Long userId) {
+
+        commentLikeService.delete(userId, commentId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/server/src/main/java/com/dialog/server/controller/resolver/AuthenticatedUserIdArgumentResolver.java
+++ b/server/src/main/java/com/dialog/server/controller/resolver/AuthenticatedUserIdArgumentResolver.java
@@ -27,13 +27,22 @@ public class AuthenticatedUserIdArgumentResolver implements HandlerMethodArgumen
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
+        AuthenticatedUserId annotation = parameter.getParameterAnnotation(AuthenticatedUserId.class);
+        boolean required = annotation == null || annotation.required();
+
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null) {
+            if (!required) {
+                return null;
+            }
             throw new DialogException(ErrorCode.AUTHENTICATION_NOT_FOUND);
         }
 
         if (authentication instanceof AnonymousAuthenticationToken) {
+            if (!required) {
+                return null;
+            }
             throw new DialogException(ErrorCode.LOGIN_REQUIRED);
         }
 

--- a/server/src/main/java/com/dialog/server/domain/CommentLike.java
+++ b/server/src/main/java/com/dialog/server/domain/CommentLike.java
@@ -1,0 +1,41 @@
+package com.dialog.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comment_likes")
+@Entity
+public class CommentLike {
+
+    @Column(name = "comment_like_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "discussion_comment_id", nullable = false)
+    private DiscussionComment comment;
+
+    @Builder
+    private CommentLike(Long id, User user, DiscussionComment comment) {
+        this.id = id;
+        this.user = user;
+        this.comment = comment;
+    }
+}

--- a/server/src/main/java/com/dialog/server/dto/auth/AuthenticatedUserId.java
+++ b/server/src/main/java/com/dialog/server/dto/auth/AuthenticatedUserId.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthenticatedUserId {
+    boolean required() default true;
 }

--- a/server/src/main/java/com/dialog/server/dto/comment/CommentLikeCountDto.java
+++ b/server/src/main/java/com/dialog/server/dto/comment/CommentLikeCountDto.java
@@ -1,0 +1,3 @@
+package com.dialog.server.dto.comment;
+
+public record CommentLikeCountDto(Long commentId, Long likeCount) {}

--- a/server/src/main/java/com/dialog/server/dto/comment/response/DiscussionCommentListResponse.java
+++ b/server/src/main/java/com/dialog/server/dto/comment/response/DiscussionCommentListResponse.java
@@ -20,39 +20,52 @@ public record DiscussionCommentListResponse(
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
             LocalDateTime createdAt,
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-            LocalDateTime modifiedAt
+            LocalDateTime modifiedAt,
+            long likeCount,
+            boolean isLiked
     ) {
         public static DiscussionCommentResponse withChildren(
                 DiscussionComment parentComment,
                 List<DiscussionComment> childComments,
-                Map<User, ProfileImage> profileImagesByUserId) {
+                Map<User, ProfileImage> profileImagesByUserId,
+                Map<Long, Long> likeCountByCommentId,
+                java.util.Set<Long> likedCommentIds) {
 
             List<DiscussionCommentResponse> childResponses = childComments.stream()
                     .map(childComment -> DiscussionCommentResponse.from(
                             childComment,
-                            profileImagesByUserId.get(childComment.getAuthor())
+                            profileImagesByUserId.get(childComment.getAuthor()),
+                            likeCountByCommentId,
+                            likedCommentIds
                     ))
                     .toList();
 
             return DiscussionCommentResponse.from(
                     parentComment,
                     profileImagesByUserId.get(parentComment.getAuthor()),
-                    childResponses
+                    childResponses,
+                    likeCountByCommentId,
+                    likedCommentIds
             );
         }
 
-        private static DiscussionCommentResponse from(DiscussionComment comment, ProfileImage profileImage) {
-            return from(comment, profileImage, List.of());
+        private static DiscussionCommentResponse from(DiscussionComment comment, ProfileImage profileImage,
+                Map<Long, Long> likeCountByCommentId, java.util.Set<Long> likedCommentIds) {
+            return from(comment, profileImage, List.of(), likeCountByCommentId, likedCommentIds);
         }
 
-        private static DiscussionCommentResponse from(DiscussionComment comment, ProfileImage profileImage, List<DiscussionCommentResponse> childComments) {
+        private static DiscussionCommentResponse from(DiscussionComment comment, ProfileImage profileImage,
+                List<DiscussionCommentResponse> childComments,
+                Map<Long, Long> likeCountByCommentId, java.util.Set<Long> likedCommentIds) {
             return new DiscussionCommentResponse(
                     comment.getId(),
                     comment.getContent(),
                     AuthorResponse.from(comment.getAuthor(), profileImage),
                     childComments,
                     comment.getCreatedAt(),
-                    comment.getModifiedAt()
+                    comment.getModifiedAt(),
+                    likeCountByCommentId.getOrDefault(comment.getId(), 0L),
+                    likedCommentIds.contains(comment.getId())
             );
         }
 

--- a/server/src/main/java/com/dialog/server/exception/ErrorCode.java
+++ b/server/src/main/java/com/dialog/server/exception/ErrorCode.java
@@ -61,6 +61,8 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND("5060", "댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     REPLY_DEPTH_EXCEEDED("5061", "답글에 답글을 달 수 없습니다.", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED_ACCESS("5062", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ALREADY_COMMENT_LIKED("5063", "이미 좋아요를 눌렀습니다.", HttpStatus.BAD_REQUEST),
+    NOT_COMMENT_LIKED_YET("5064", "좋아요를 누르지 않았습니다.", HttpStatus.BAD_REQUEST),
 
     NOT_OFFLINE_DISCUSSION("5071", "오프라인 토론이 아닙니다.", HttpStatus.BAD_REQUEST),
     NOT_ONLINE_DISCUSSION("5072", "온라인 토론이 아닙니다.", HttpStatus.BAD_REQUEST),

--- a/server/src/main/java/com/dialog/server/repository/CommentLikeRepository.java
+++ b/server/src/main/java/com/dialog/server/repository/CommentLikeRepository.java
@@ -1,0 +1,24 @@
+package com.dialog.server.repository;
+
+import com.dialog.server.domain.CommentLike;
+import com.dialog.server.domain.DiscussionComment;
+import com.dialog.server.domain.User;
+import com.dialog.server.dto.comment.CommentLikeCountDto;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    boolean existsByUserAndComment(User user, DiscussionComment comment);
+
+    void deleteByUserAndComment(User user, DiscussionComment comment);
+
+    @Query("SELECT new com.dialog.server.dto.comment.CommentLikeCountDto(cl.comment.id, COUNT(cl)) " +
+           "FROM CommentLike cl WHERE cl.comment.id IN :commentIds GROUP BY cl.comment.id")
+    List<CommentLikeCountDto> countByCommentIdIn(@Param("commentIds") List<Long> commentIds);
+
+    @Query("SELECT cl.comment.id FROM CommentLike cl WHERE cl.user = :user AND cl.comment.id IN :commentIds")
+    List<Long> findLikedCommentIdsByUserAndCommentIdIn(@Param("user") User user, @Param("commentIds") List<Long> commentIds);
+}

--- a/server/src/main/java/com/dialog/server/service/CommentLikeService.java
+++ b/server/src/main/java/com/dialog/server/service/CommentLikeService.java
@@ -1,0 +1,54 @@
+package com.dialog.server.service;
+
+import com.dialog.server.domain.CommentLike;
+import com.dialog.server.domain.DiscussionComment;
+import com.dialog.server.domain.User;
+import com.dialog.server.exception.DialogException;
+import com.dialog.server.exception.ErrorCode;
+import com.dialog.server.repository.CommentLikeRepository;
+import com.dialog.server.repository.DiscussionCommentRepository;
+import com.dialog.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+
+    private final CommentLikeRepository commentLikeRepository;
+    private final UserRepository userRepository;
+    private final DiscussionCommentRepository discussionCommentRepository;
+
+    @Transactional
+    public void create(Long userId, Long commentId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
+        DiscussionComment comment = discussionCommentRepository.findById(commentId)
+                .orElseThrow(() -> new DialogException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (commentLikeRepository.existsByUserAndComment(user, comment)) {
+            throw new DialogException(ErrorCode.ALREADY_COMMENT_LIKED);
+        }
+
+        CommentLike commentLike = CommentLike.builder()
+                .user(user)
+                .comment(comment)
+                .build();
+        commentLikeRepository.save(commentLike);
+    }
+
+    @Transactional
+    public void delete(Long userId, Long commentId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
+        DiscussionComment comment = discussionCommentRepository.findById(commentId)
+                .orElseThrow(() -> new DialogException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (!commentLikeRepository.existsByUserAndComment(user, comment)) {
+            throw new DialogException(ErrorCode.NOT_COMMENT_LIKED_YET);
+        }
+
+        commentLikeRepository.deleteByUserAndComment(user, comment);
+    }
+}

--- a/server/src/main/java/com/dialog/server/service/DiscussionCommentService.java
+++ b/server/src/main/java/com/dialog/server/service/DiscussionCommentService.java
@@ -8,18 +8,22 @@ import com.dialog.server.domain.NotificationType;
 import com.dialog.server.domain.ProfileImage;
 import com.dialog.server.domain.RouteParams;
 import com.dialog.server.domain.User;
+import com.dialog.server.dto.comment.CommentLikeCountDto;
 import com.dialog.server.dto.comment.request.DiscussionCommentCreateRequest;
 import com.dialog.server.dto.comment.response.DiscussionCommentCreateResponse;
 import com.dialog.server.dto.comment.response.DiscussionCommentListResponse;
 import com.dialog.server.dto.comment.response.DiscussionCommentListResponse.DiscussionCommentResponse;
 import com.dialog.server.exception.DialogException;
 import com.dialog.server.exception.ErrorCode;
+import com.dialog.server.repository.CommentLikeRepository;
 import com.dialog.server.repository.DiscussionCommentRepository;
 import com.dialog.server.repository.DiscussionRepository;
 import com.dialog.server.repository.ProfileImageRepository;
 import com.dialog.server.repository.UserRepository;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +41,7 @@ public class DiscussionCommentService {
     private final UserRepository userRepository;
     private final ProfileImageRepository profileImageRepository;
     private final NotificationService notificationService;
+    private final CommentLikeRepository commentLikeRepository;
 
     @Transactional
     public DiscussionCommentCreateResponse createComment(DiscussionCommentCreateRequest request, Long authorId) {
@@ -93,7 +98,7 @@ public class DiscussionCommentService {
     }
 
     @Transactional(readOnly = true)
-    public DiscussionCommentListResponse getCommentsByDiscussionId(Long discussionId) {
+    public DiscussionCommentListResponse getCommentsByDiscussionId(Long discussionId, Long userId) {
         Discussion discussion = discussionRepository.findById(discussionId)
                 .orElseThrow(() -> new DialogException(ErrorCode.NOT_FOUND_DISCUSSION));
 
@@ -105,11 +110,26 @@ public class DiscussionCommentService {
 
         final Map<User, ProfileImage> authorProfileImages = getAuthorProfileImages(discussionComments);
 
+        List<Long> commentIds = discussionComments.stream().map(DiscussionComment::getId).toList();
+        Map<Long, Long> likeCountByCommentId = commentLikeRepository.countByCommentIdIn(commentIds).stream()
+                .collect(Collectors.toMap(CommentLikeCountDto::commentId, CommentLikeCountDto::likeCount));
+
+        Set<Long> likedCommentIds;
+        if (userId != null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new DialogException(ErrorCode.USER_NOT_FOUND));
+            likedCommentIds = Set.copyOf(commentLikeRepository.findLikedCommentIdsByUserAndCommentIdIn(user, commentIds));
+        } else {
+            likedCommentIds = Collections.emptySet();
+        }
+
         List<DiscussionCommentResponse> parentCommentResponses = parentComments.stream()
                 .map(parentComment -> DiscussionCommentResponse.withChildren(
                         parentComment,
                         childCommentsByParentId.getOrDefault(parentComment.getId(), List.of()),
-                        authorProfileImages
+                        authorProfileImages,
+                        likeCountByCommentId,
+                        likedCommentIds
                 ))
                 .toList();
         return new DiscussionCommentListResponse(parentCommentResponses);

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -87,7 +87,7 @@ aws:
 
 
 sentry:
-  dsn: ${SENTRY_DSN}
+  dsn: ${SENTRY_DSN:}
   environment: production
   send-default-pii: false
   in-app-includes: com.dialog.server

--- a/server/src/main/resources/static/docs/api/comment-like-controller-openapi.yaml
+++ b/server/src/main/resources/static/docs/api/comment-like-controller-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
-  title: Dialog Discussion Like API
-  description: 토론 좋아요 기능 관리를 위한 API
+  title: Dialog Comment Like API
+  description: 댓글 좋아요 기능 관리를 위한 API
   version: 1.0.0
   contact:
     name: Dialog Team
@@ -11,24 +11,24 @@ servers:
     description: 프로덕션 서버
 
 tags:
-  - name: Discussion Like
-    description: 토론 좋아요 관리
+  - name: Comment Like
+    description: 댓글 좋아요 관리
 
 paths:
-  /api/discussions/{discussionsId}/likes:
+  /api/discussions/comments/{commentId}/likes:
     post:
       tags:
-        - Discussion Like
-      summary: 좋아요 추가
-      description: 특정 토론에 좋아요를 추가합니다. 이미 좋아요가 되어있으면 중복되지 않습니다.
-      operationId: addLike
+        - Comment Like
+      summary: 댓글 좋아요 추가
+      description: 특정 댓글에 좋아요를 추가합니다.
+      operationId: addCommentLike
       security:
-        - sessionAuth: [ ]
+        - sessionAuth: []
       parameters:
-        - name: discussionsId
+        - name: commentId
           in: path
           required: true
-          description: 토론 ID
+          description: 좋아요를 추가할 댓글 ID
           schema:
             type: integer
             format: int64
@@ -46,21 +46,21 @@ paths:
               example:
                 data: null
         'error-codes':
-          description: "[1005, 5022]"
+          description: "[1005, 5060, 5063]"
 
     delete:
       tags:
-        - Discussion Like
-      summary: 좋아요 취소
-      description: 특정 토론의 좋아요를 취소합니다.
-      operationId: removeLike
+        - Comment Like
+      summary: 댓글 좋아요 취소
+      description: 특정 댓글의 좋아요를 취소합니다.
+      operationId: removeCommentLike
       security:
-        - sessionAuth: [ ]
+        - sessionAuth: []
       parameters:
-        - name: discussionsId
+        - name: commentId
           in: path
           required: true
-          description: 토론 ID
+          description: 좋아요를 취소할 댓글 ID
           schema:
             type: integer
             format: int64
@@ -68,7 +68,7 @@ paths:
         '204':
           description: 좋아요 취소 성공 (응답 본문 없음)
         'error-codes':
-          description: "[1005, 5022]"
+          description: "[1005, 5060, 5064]"
 
 components:
   securitySchemes:

--- a/server/src/main/resources/static/docs/api/components/schemas/comment.yaml
+++ b/server/src/main/resources/static/docs/api/components/schemas/comment.yaml
@@ -71,6 +71,8 @@ components:
         - childComments
         - createdAt
         - modifiedAt
+        - likeCount
+        - isLiked
       properties:
         discussionCommentId:
           type: integer
@@ -98,6 +100,15 @@ components:
           format: date-time
           description: 수정 일시
           example: "2025-11-14T11:00:00"
+        likeCount:
+          type: integer
+          format: int64
+          description: 댓글 좋아요 수
+          example: 5
+        isLiked:
+          type: boolean
+          description: 현재 로그인한 사용자의 좋아요 여부 (비로그인 시 항상 false)
+          example: true
 
     DiscussionComment_AuthorResponse:
       type: object

--- a/server/src/main/resources/static/docs/api/discussion-comment-controller-openapi.yaml
+++ b/server/src/main/resources/static/docs/api/discussion-comment-controller-openapi.yaml
@@ -148,7 +148,14 @@ paths:
         - 최상위 댓글들이 반환됩니다
         - 각 댓글은 `childComments` 배열에 대댓글을 포함합니다
         - 계층 구조로 조회됩니다
+
+        **인증:**
+        - 로그인 상태이면 `isLiked`가 실제 좋아요 여부를 반환합니다
+        - 비로그인 상태이면 `isLiked`는 항상 `false`를 반환합니다
       operationId: getComments
+      security:
+        - sessionAuth: []
+        - {}
       parameters:
         - name: discussionId
           in: path
@@ -167,31 +174,56 @@ paths:
                 properties:
                   data:
                     $ref: './components/schemas/comment.yaml#/components/schemas/DiscussionCommentListResponse'
-              example:
-                data:
-                  discussionComments:
-                    - discussionCommentId: 1
-                      content: "좋은 의견입니다!"
-                      author:
-                        authorId: 123
-                        nickname: "홍길동"
-                        profileImage:
-                          customImageUri: "https://s3.amazonaws.com/dialog/profiles/user123.jpg"
-                          basicImageUri: "https://avatars.githubusercontent.com/u/12345"
-                      childComments:
-                        - discussionCommentId: 2
-                          content: "동의합니다."
+              examples:
+                loggedIn:
+                  summary: 로그인 상태 (isLiked 실제 값 반영)
+                  value:
+                    data:
+                      discussionComments:
+                        - discussionCommentId: 1
+                          content: "좋은 의견입니다!"
                           author:
-                            authorId: 456
-                            nickname: "김철수"
+                            authorId: 123
+                            nickname: "홍길동"
                             profileImage:
-                              customImageUri: null
-                              basicImageUri: "https://avatars.githubusercontent.com/u/67890"
+                              customImageUri: "https://s3.amazonaws.com/dialog/profiles/user123.jpg"
+                              basicImageUri: "https://avatars.githubusercontent.com/u/12345"
+                          childComments:
+                            - discussionCommentId: 2
+                              content: "동의합니다."
+                              author:
+                                authorId: 456
+                                nickname: "김철수"
+                                profileImage:
+                                  customImageUri: null
+                                  basicImageUri: "https://avatars.githubusercontent.com/u/67890"
+                              childComments: []
+                              createdAt: "2025-11-13T10:35:00"
+                              modifiedAt: "2025-11-13T10:35:00"
+                              likeCount: 0
+                              isLiked: false
+                          createdAt: "2025-11-13T10:30:00"
+                          modifiedAt: "2025-11-13T10:30:00"
+                          likeCount: 5
+                          isLiked: true
+                anonymous:
+                  summary: 비로그인 상태 (isLiked 항상 false)
+                  value:
+                    data:
+                      discussionComments:
+                        - discussionCommentId: 1
+                          content: "좋은 의견입니다!"
+                          author:
+                            authorId: 123
+                            nickname: "홍길동"
+                            profileImage:
+                              customImageUri: "https://s3.amazonaws.com/dialog/profiles/user123.jpg"
+                              basicImageUri: "https://avatars.githubusercontent.com/u/12345"
                           childComments: []
-                          createdAt: "2025-11-13T10:35:00"
-                          modifiedAt: "2025-11-13T10:35:00"
-                      createdAt: "2025-11-13T10:30:00"
-                      modifiedAt: "2025-11-13T10:30:00"
+                          createdAt: "2025-11-13T10:30:00"
+                          modifiedAt: "2025-11-13T10:30:00"
+                          likeCount: 5
+                          isLiked: false
         'error-codes':
           description: "[5022]"
 

--- a/server/src/test/java/com/dialog/server/service/CommentLikeServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/CommentLikeServiceTest.java
@@ -1,0 +1,198 @@
+package com.dialog.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dialog.server.config.JpaConfig;
+import com.dialog.server.domain.Category;
+import com.dialog.server.domain.CommentLike;
+import com.dialog.server.domain.Discussion;
+import com.dialog.server.domain.DiscussionComment;
+import com.dialog.server.domain.OfflineDiscussion;
+import com.dialog.server.domain.User;
+import com.dialog.server.exception.DialogException;
+import com.dialog.server.exception.ErrorCode;
+import com.dialog.server.repository.CommentLikeRepository;
+import com.dialog.server.repository.DiscussionCommentRepository;
+import com.dialog.server.repository.DiscussionRepository;
+import com.dialog.server.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Import(JpaConfig.class)
+@ActiveProfiles("test")
+@DataJpaTest
+class CommentLikeServiceTest {
+
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private DiscussionRepository discussionRepository;
+
+    @Autowired
+    private DiscussionCommentRepository discussionCommentRepository;
+
+    private CommentLikeService commentLikeService;
+
+    @BeforeEach
+    void setUp() {
+        commentLikeService = new CommentLikeService(commentLikeRepository, userRepository, discussionCommentRepository);
+    }
+
+    @Test
+    void 사용자는_댓글에_좋아요를_할_수_있다() {
+        // given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+        DiscussionComment comment = createComment(discussion, user);
+
+        // when
+        commentLikeService.create(user.getId(), comment.getId());
+
+        // then
+        assertThat(commentLikeRepository.existsByUserAndComment(user, comment)).isTrue();
+    }
+
+    @Test
+    void 좋아요를_할때_이미_좋아요를_눌렀다면_예외가_발생한다() {
+        // given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+        DiscussionComment comment = createComment(discussion, user);
+        createCommentLike(user, comment);
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.create(user.getId(), comment.getId()))
+                .isInstanceOf(DialogException.class)
+                .hasMessage(ErrorCode.ALREADY_COMMENT_LIKED.message);
+    }
+
+    @Test
+    void 존재하지_않는_사용자는_댓글에_좋아요를_할_수_없다() {
+        // given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+        DiscussionComment comment = createComment(discussion, user);
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.create(999L, comment.getId()))
+                .isInstanceOf(DialogException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.message);
+    }
+
+    @Test
+    void 존재하지_않는_댓글에_좋아요를_할_수_없다() {
+        // given
+        User user = createUser();
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.create(user.getId(), 999L))
+                .isInstanceOf(DialogException.class)
+                .hasMessage(ErrorCode.COMMENT_NOT_FOUND.message);
+    }
+
+    @Test
+    void 사용자는_댓글에_대해_좋아요를_취소할_수_있다() {
+        // given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+        DiscussionComment comment = createComment(discussion, user);
+        createCommentLike(user, comment);
+
+        // when
+        commentLikeService.delete(user.getId(), comment.getId());
+
+        // then
+        assertThat(commentLikeRepository.existsByUserAndComment(user, comment)).isFalse();
+    }
+
+    @Test
+    void 좋아요를_취소할때_좋아요를_누르지_않은_상태라면_예외가_발생한다() {
+        // given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+        DiscussionComment comment = createComment(discussion, user);
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.delete(user.getId(), comment.getId()))
+                .isInstanceOf(DialogException.class)
+                .hasMessage(ErrorCode.NOT_COMMENT_LIKED_YET.message);
+    }
+
+    @Test
+    void 존재하지_않는_사용자는_댓글_좋아요를_취소할_수_없다() {
+        // given
+        User user = createUser();
+        Discussion discussion = createDiscussion(user);
+        DiscussionComment comment = createComment(discussion, user);
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.delete(999L, comment.getId()))
+                .isInstanceOf(DialogException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.message);
+    }
+
+    @Test
+    void 존재하지_않는_댓글의_좋아요를_취소할_수_없다() {
+        // given
+        User user = createUser();
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.delete(user.getId(), 999L))
+                .isInstanceOf(DialogException.class)
+                .hasMessage(ErrorCode.COMMENT_NOT_FOUND.message);
+    }
+
+    private User createUser() {
+        User user = User.builder()
+                .nickname("test")
+                .webPushNotification(false)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Discussion createDiscussion(User author) {
+        Discussion discussion = OfflineDiscussion.builder()
+                .author(author)
+                .category(Category.BACKEND)
+                .content("content")
+                .startAt(LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(15, 0)))
+                .endAt(LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(17, 0)))
+                .title("title")
+                .maxParticipantCount(3)
+                .participantCount(1)
+                .place("place")
+                .summary("summary")
+                .build();
+        return discussionRepository.save(discussion);
+    }
+
+    private DiscussionComment createComment(Discussion discussion, User author) {
+        DiscussionComment comment = DiscussionComment.builder()
+                .content("테스트 댓글")
+                .discussion(discussion)
+                .author(author)
+                .parentDiscussionComment(null)
+                .build();
+        return discussionCommentRepository.save(comment);
+    }
+
+    private CommentLike createCommentLike(User user, DiscussionComment comment) {
+        CommentLike commentLike = CommentLike.builder()
+                .user(user)
+                .comment(comment)
+                .build();
+        return commentLikeRepository.save(commentLike);
+    }
+}

--- a/server/src/test/java/com/dialog/server/service/DiscussionCommentServiceTest.java
+++ b/server/src/test/java/com/dialog/server/service/DiscussionCommentServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.dialog.server.domain.Category;
+import com.dialog.server.domain.CommentLike;
 import com.dialog.server.domain.CommentReplyRouteParams;
 import com.dialog.server.domain.Discussion;
 import com.dialog.server.domain.DiscussionComment;
@@ -21,6 +22,7 @@ import com.dialog.server.dto.comment.response.DiscussionCommentListResponse;
 import com.dialog.server.dto.comment.response.DiscussionCommentListResponse.DiscussionCommentResponse;
 import com.dialog.server.exception.DialogException;
 import com.dialog.server.exception.ErrorCode;
+import com.dialog.server.repository.CommentLikeRepository;
 import com.dialog.server.repository.DiscussionCommentRepository;
 import com.dialog.server.repository.DiscussionRepository;
 import com.dialog.server.repository.NotificationRepository;
@@ -55,6 +57,8 @@ class DiscussionCommentServiceTest {
     private ProfileImageRepository profileImageRepository;
     @Autowired
     private NotificationRepository notificationRepository;
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
 
     private User author1;
     private User author2;
@@ -189,7 +193,7 @@ class DiscussionCommentServiceTest {
         discussionCommentRepository.save(createReplyComment(discussion, author2, parentComment2, "세 번째 답글"));
 
         // when
-        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(discussion.getId());
+        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(discussion.getId(), null);
 
         // then
         DiscussionCommentResponse firstParent = response.discussionComments().get(0);
@@ -210,7 +214,7 @@ class DiscussionCommentServiceTest {
         Discussion discussion = discussionRepository.save(createDiscussion(author1));
 
         // when
-        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(discussion.getId());
+        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(discussion.getId(), null);
 
         // then
         assertThat(response.discussionComments()).isEmpty();
@@ -219,7 +223,7 @@ class DiscussionCommentServiceTest {
     @Test
     void 존재하지_않는_토론글의_댓글_목록을_조회할_수_없다() {
         // when & then
-        assertThatThrownBy(() -> discussionCommentService.getCommentsByDiscussionId(999L))
+        assertThatThrownBy(() -> discussionCommentService.getCommentsByDiscussionId(999L, null))
                 .isInstanceOf(DialogException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_DISCUSSION.message);
     }
@@ -395,6 +399,70 @@ class DiscussionCommentServiceTest {
     }
 
     @Test
+    void 댓글_목록_조회_시_좋아요_수가_포함된다() {
+        // given
+        Discussion newDiscussion = discussionRepository.save(createDiscussion(author1));
+        DiscussionComment parentComment = discussionCommentRepository.save(createComment(newDiscussion, author1, "부모댓글"));
+        DiscussionComment childComment = discussionCommentRepository.save(createReplyComment(newDiscussion, author2, parentComment, "답글"));
+
+        commentLikeRepository.save(createCommentLike(author1, parentComment));
+        commentLikeRepository.save(createCommentLike(author2, parentComment));
+        commentLikeRepository.save(createCommentLike(author1, childComment));
+
+        // when
+        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(newDiscussion.getId(), null);
+
+        // then
+        DiscussionCommentResponse parentResponse = response.discussionComments().get(0);
+        DiscussionCommentResponse childResponse = parentResponse.childComments().get(0);
+
+        assertAll(
+                () -> assertThat(parentResponse.likeCount()).isEqualTo(2),
+                () -> assertThat(childResponse.likeCount()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void 댓글_목록_조회_시_로그인한_사용자의_좋아요_여부가_포함된다() {
+        // given
+        Discussion newDiscussion = discussionRepository.save(createDiscussion(author1));
+        DiscussionComment likedComment = discussionCommentRepository.save(createComment(newDiscussion, author1, "좋아요한 댓글"));
+        DiscussionComment notLikedComment = discussionCommentRepository.save(createComment(newDiscussion, author2, "좋아요 안 한 댓글"));
+
+        commentLikeRepository.save(createCommentLike(author2, likedComment));
+
+        // when
+        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(newDiscussion.getId(), author2.getId());
+
+        // then
+        DiscussionCommentResponse likedResponse = response.discussionComments().stream()
+                .filter(r -> r.discussionCommentId().equals(likedComment.getId()))
+                .findFirst().orElseThrow();
+        DiscussionCommentResponse notLikedResponse = response.discussionComments().stream()
+                .filter(r -> r.discussionCommentId().equals(notLikedComment.getId()))
+                .findFirst().orElseThrow();
+
+        assertAll(
+                () -> assertThat(likedResponse.isLiked()).isTrue(),
+                () -> assertThat(notLikedResponse.isLiked()).isFalse()
+        );
+    }
+
+    @Test
+    void 댓글_목록_조회_시_비로그인이면_isLiked가_false다() {
+        // given
+        Discussion newDiscussion = discussionRepository.save(createDiscussion(author1));
+        DiscussionComment commentWithLike = discussionCommentRepository.save(createComment(newDiscussion, author1, "좋아요 있는 댓글"));
+        commentLikeRepository.save(createCommentLike(author2, commentWithLike));
+
+        // when
+        DiscussionCommentListResponse response = discussionCommentService.getCommentsByDiscussionId(newDiscussion.getId(), null);
+
+        // then
+        assertThat(response.discussionComments().get(0).isLiked()).isFalse();
+    }
+
+    @Test
     void 자신의_댓글에_답글을_작성하면_알림이_생성되지_않는다() {
         // given
         Discussion discussion = discussionRepository.save(createDiscussion(author2));
@@ -468,6 +536,13 @@ class DiscussionCommentServiceTest {
                 .discussion(discussion)
                 .author(author)
                 .parentDiscussionComment(parentComment)
+                .build();
+    }
+
+    private CommentLike createCommentLike(User user, DiscussionComment comment) {
+        return CommentLike.builder()
+                .user(user)
+                .comment(comment)
                 .build();
     }
 


### PR DESCRIPTION
# 📋 연관 이슈

없음

# 🚀 작업 내용

## 서버

- **CommentLike 엔티티 추가** (`comment_likes` 테이블): `Like.java`와 동일한 구조로 `DiscussionComment`에 대한 좋아요 도메인 추가
- **CommentLikeRepository 추가**: 댓글별 좋아요 수/여부 배치 조회 쿼리 2개 추가 (N+1 방지)
  ```java
  List<CommentLikeCountDto> countByCommentIdIn(List<Long> commentIds);
  List<Long> findLikedCommentIdsByUserAndCommentIdIn(User user, List<Long> commentIds);
  ```
- **CommentLikeService 추가**: 좋아요 추가 (`ALREADY_COMMENT_LIKED`) / 취소 (`NOT_COMMENT_LIKED_YET`) 처리
- **댓글 목록 응답에 `likeCount`, `isLiked` 필드 추가**: 비로그인 시 `isLiked = false` 반환
- **AuthenticatedUserId 어노테이션 `required` 속성 추가**: `required = false`이면 비로그인 시 `null` 반환
- **에러코드 추가**: `ALREADY_COMMENT_LIKED(5063)`, `NOT_COMMENT_LIKED_YET(5064)`
- **신규 API 엔드포인트 추가**
  - `POST /api/discussions/comments/{commentId}/likes` — 따봉 추가
  - `DELETE /api/discussions/comments/{commentId}/likes` — 따봉 취소
  - `GET /api/discussions/{discussionId}/comments` — 옵셔널 인증 추가 (비로그인도 조회 가능)
- **테스트 추가**: `CommentLikeServiceTest` (8개), `DiscussionCommentServiceTest` likeCount/isLiked 관련 3개 추가

## 클라이언트

- **commentLike API 함수 추가** (`likeComment`, `unlikeComment`)
- **CommentItem Slack 스타일 따봉 UI 구현**
  - 좋아요 0개이면 pill 숨김, 1개 이상이면 `👍 N` pill 노출
  - 😊+ 버튼 클릭 시 👍 팝오버 표시 (외부 클릭/ESC로 닫힘)
  - 팝오버에서 👍 클릭 또는 pill 직접 클릭으로 따봉 토글
  - 낙관적 업데이트 적용 (API 실패 시 롤백)
  - 비로그인 사용자는 pill 읽기 전용, 피커 미노출

## 기타

- **API 문서 업데이트**: `comment-like-controller-openapi.yaml` 신규 추가, 댓글 목록 응답 스키마/예시 갱신
- **application-local.yml**: `SENTRY_DSN` 플레이스홀더 기본값 추가 (`${SENTRY_DSN:}`) — 로컬 환경변수 없을 때 기동 오류 수정

# 💬 리뷰 중점 사항

- **CommentLikeRepository 배치 쿼리**: `countByCommentIdIn`, `findLikedCommentIdsByUserAndCommentIdIn`으로 N+1 방지 — 쿼리 정확성 확인
- **AuthenticatedUserIdArgumentResolver**: `required = false`일 때 `AnonymousAuthenticationToken`이면 `null` 반환 — 기존 `required = true` 동작에 영향 없는지 확인
- **낙관적 업데이트**: API 실패 시 state 롤백 — 에러 처리 방식 적절한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)